### PR TITLE
patched bug in multiRotatePauli

### DIFF
--- a/QuEST/src/QuEST_common.c
+++ b/QuEST/src/QuEST_common.c
@@ -412,8 +412,8 @@ void statevec_multiRotatePauli(
     qreal fac = 1/sqrt(2);
     Complex uRxAlpha = {.real = fac, .imag = 0}; // Rx(pi/2)* rotates Z -> Y
     Complex uRxBeta = {.real = 0, .imag = (applyConj)? fac : -fac};
-    Complex uRyAlpha = {.real = fac, .imag = 0}; // Ry(pi/2) rotates Z -> X
-    Complex uRyBeta = {.real = fac, .imag = 0};
+    Complex uRyAlpha = {.real = fac, .imag = 0}; // Ry(-pi/2) rotates Z -> X
+    Complex uRyBeta = {.real = -fac, .imag = 0};
     
     // mask may be modified to remove superfluous Identity ops
     long long int mask = getQubitBitMask(targetQubits, numTargets);


### PR DESCRIPTION
A rotation in the X basis was being performed by an initial incorrect rotation of Ry(pi/2) followed by a Z basis rotation. The correct basis rotation Z -> X is performed with Ry(-pi/2).