### PR TITLE
Overhauling validation and error handling

### DIFF
--- a/QuEST/include/QuEST.h
+++ b/QuEST/include/QuEST.h
@@ -207,14 +207,11 @@ typedef struct QuESTEnv
 /*
  * Added for Mathematica front-end 
  */
- 
-/** exposed for MMA statevec access */
-void copyStateFromGPU(Qureg qureg);
 
 /** exposed for MMA get-deriv-of-circuits (deriv of controlled gates) */
 void projectToOne(Qureg qureg, const int measureQubit);
 
-/** exposed for MMA get-deriv-of-circuits (deriv of general unitary gates */
+/** exposed for MMA get-deriv-of-circuits (deriv of general unitary gates) */
 void applyOneQubitMatrix(Qureg qureg, int targetQubit,  ComplexMatrix2 u);
 void applyTwoQubitMatrix(Qureg qureg, int targetQubit1, int targetQubit2, ComplexMatrix4 u);
 

--- a/QuEST/include/QuEST.h
+++ b/QuEST/include/QuEST.h
@@ -160,9 +160,6 @@ typedef struct Vector
  */
 typedef struct Qureg
 {
-    // for MMA
-    int isCreated;
-
     //! Whether this instance is a density-state representation
     int isDensityMatrix;
     //! The number of qubits represented in either the state-vector or density matrix

--- a/QuESTlink.m
+++ b/QuESTlink.m
@@ -290,12 +290,12 @@ P[outcomes] is a (normalised) projector onto the given {0,1} outcomes. The left 
         DestroyQureg[qureg_Symbol] :=
         	Block[{}, DestroyQuregInternal[ReleaseHold@qureg]; Clear[qureg]]
 
-        (* get a local matrix representation of the qureg. GetStateVecInternal provided by WSTP *)
+        (* get a local matrix representation of the qureg. GetQuregMatrixInternal provided by WSTP *)
         GetQuregMatrix[qureg_Integer] :=
-        	With[{data = GetStateVecInternal[qureg]},
+        	With[{data = GetQuregMatrixInternal[qureg]},
         		Which[
-        			data === -1,
-        			$Failed,
+        			Or[data === $Failed, data === $Aborted],
+        			data,
         			data[[2]] === 0,
         			MapThread[#1 + I #2 &, {data[[3]], data[[4]]}],
         			data[[2]] === 1,

--- a/QuESTlink.m
+++ b/QuESTlink.m
@@ -14,57 +14,79 @@ BeginPackage["QuEST`"]
     
     ApplyCircuit::usage = "ApplyCircuit[circuit, qureg] modifies qureg by applying the circuit. Returns any measurement outcomes, grouped by M operators and ordered by their order in M.
 ApplyCircuit[circuit, inQureg, outQureg] leaves inQureg unchanged, but modifies outQureg to be the result of applying the circuit to inQureg."
+    ApplyCircuit::error = "`1`"
     
     CalcQuregDerivs::usage = "CalcQuregDerivs[circuit, initQureg, varVals, derivQuregs] sets the given list of (deriv)quregs to be the result of applying derivatives of the parameterised circuit to the initial state. The derivQuregs are ordered by the varVals, which should be in the format {param -> value}, where param is featured in Rx, Ry, Rz, R or U (and controlled) of the given circuit ONCE (multiple times within a U matrix is allowed). The initState is unchanged. Note Rx[theta] is allowed, but Rx[f(theta)] is not. Furthermore U matrices must contain at most one parameter."
+    CalcQuregDerivs::error = "`1`"
     
     CalcInnerProducts::usage = "CalcInnerProducts[quregIds] returns a Hermitian matrix with i-th j-th element CalcInnerProduct[quregIds[i], quregIds[j]].
 CalcInnerProducts[braId, ketIds] returns a complex vector with i-th element CalcInnerProduct[braId, ketIds[i]]."
+    CalcInnerProducts::error = "`1`"
 
     CalcDensityInnerProducts::usage = "CalcDensityInnerProducts[quregIds] returns a real, symmetric matrix with i-th j-th element CalcDensityInnerProduct[quregIds[i], quregIds[j]].
 CalcDensityInnerProducts[rhoId, omegaIds] returns a real vector with i-th element CalcDensityInnerProduct[rhoId, omegaIds[i]]."
+    CalcDensityInnerProducts::error = "`1`"
     
     Circuit::usage = "Circuit[gates] converts a product of gates into a left-to-right circuit, preserving order."
+    Circuit::error = "`1`"
     
     Operator::usage = "Operator[gates] converts a product of gates into a right-to-left circuit."
+    Operator::error = "`1`"
     
     CalcExpecPauliProd::usage = "CalcExpecPauliProd[qureg, paulis, workspace] evaluates the expected value of a product of Paulis. workspace must be a qureg of equal dimensions to qureg."
+    CalcExpecPauliProd::error = "`1`"
 
     CalcExpecPauliSum::usage = "CalcExpecPauliSum[qureg, pauliSum, workspace] evaluates the expected value of a weighted sum of Pauli products, of a normalised qureg. workspace must be a qureg of equal dimensions to qureg. qureg is unchanged, and workspace is modified."
+    CalcExpecPauliSum::error = "`1`"
 
     ApplyPauliSum::usage = "ApplyPauliSum[inQureg, pauliSum, outQureg] modifies outQureg to be the result of applying the weighted sum of Paulis to inQureg."
+    ApplyPauliSum::error = "`1`"
 
     CalcPauliSumMatrix::usage = "CalcPauliSumMatrix[pauliSum] returns the matrix form of the given weighted sum of Pauli operators. The number of qubits is assumed to be the largest Pauli target."
+    CalcPauliSumMatrix::error = "`1`"
 
     DestroyQureg::usage = "DestroyQureg[qureg] destroys the qureg associated with the given ID or symbol."
+    DestroyQureg::error = "`1`"
     
     GetAmp::usage = "GetAmp[qureg, index] returns the complex amplitude of the state-vector qureg at the given index.
 GetAmp[qureg, row, col] returns the complex amplitude of the density-matrix qureg at index [row, col]."
+    GetAmp::error = "`1`"
     
     GetQuregMatrix::usage = "GetQuregMatrix[qureg] returns the state-vector or density matrix associated with the given qureg."
-            
+    GetQuregMatrix::error = "`1`"
+    
     SetQuregMatrix::usage = "SetQuregMatrix[qureg, matr] modifies qureg, overwriting its statevector or density matrix with that passed."
-        
+    SetQuregMatrix::error = "`1`"
+    
     GetPauliSumFromCoeffs::usage = "GetPauliSumFromCoeffs[addr] opens or downloads the file at addr (a string, of a file location or URL), and interprets it as a list of coefficients and Pauli codes, converting this to a symbolic weighted sum of Pauli products. Each line of the file is a separate term (a Pauli product), with format {coeff code1 code2 ... codeN} (exclude braces) where the codes are in {0,1,2,3} (indicating a I, X, Y, Z term in the product respectively), for an N-qubit operator. Each line must have N+1 terms (including the real decimal coefficient at the beginning)."
-            
+    GetPauliSumFromCoeffs::error = "`1`"
+    
     CreateRemoteQuESTEnv::usage = "CreateRemoteQuESTEnv[ip, port1, port2] connects to a remote QuESTlink server at ip, at the given ports, and defines several QuEST functions, returning a link object. This should be called once. The QuEST function defintions can be cleared with DestroyQuESTEnv[link]."
-             
+    CreateRemoteQuESTEnv::error = "`1`"
+    
     CreateLocalQuESTEnv::usage = "CreateLocalQuESTEnv[fn] connects to a local 'quest_link' executable, located at fn, running single-CPU QuEST. This should be called once. The QuEST function defintions can be cleared with DestroyQuESTEnv[link].
 CreateLocalQuESTEnv[] connects to a 'quest_link' executable in the working directory."
+    CreateLocalQuESTEnv::error = "`1`"
     
     CreateDownloadedQuESTEnv::usage = "CreateDownloadedQuESTEnv[os] downloads a single-CPU QuESTlink backend from qtechtheory.org, gives it permission to run then locally connects to it. os is a string indicating the user's operating system (currently only 'MacOS' is supported, which is default). This should be called once. The QuEST function defintions can be cleared with DestroyQuESTEnv[link]."
+    CreateDownloadedQuESTEnv::error = "`1`"
     
     DestroyQuESTEnv::usage = "DestroyQuESTEnv[link] disconnects from the QuEST link, which may be the remote Igor server or a loca instance, clearing some QuEST function definitions (but not those provided by the QuEST package)."
+    DestroyQuESTEnv::error = "`1`"
 
     SetWeightedQureg::usage = "SetWeightedQureg[fac1, q1, fac2, q2, facOut, qOut] modifies qureg qOut to be (facOut qOut + fac1 q1 + fac2 q2). qOut can be one of q1 an q2.
 SetWeightedQureg[fac1, q1, fac2, q2, qOut] modifies qureg qOut to be (fac1 q1 + fac2 q2). qOut can be one of q1 an q2."
+    SetWeightedQureg::error = "`1`"
 
     DrawCircuit::usage = "DrawCircuit[circuit] generates a circuit diagram.
 DrawCircuit[circuit, numQubits] generates a circuit diagram with numQubits, useful for overriding the automated inferrence of the number of qubits if incorrect.
 DrawCircuit[circuit, opts] enables Graphics options to modify the circuit diagram."
+    DrawCircuit::error = "`1`"
 
     CalcCircuitMatrix::usage = "CalcCircuitMatrix[circuit] returns an analytic expression for the given unitary circuit, which may contain undefined symbols. The number of qubits is inferred from the circuit indices (0 to maximum specified).
 CalcCircuitMatrix[circuit, numQubits] gives CalcCircuitMatrix a clue about the number of present qubits."
-            
+    CalcCircuitMatrix::error = "`1`"
+    
     (* 
      * gate symbols, needed exporting so that their use below does not refer to a private var      
      *)
@@ -179,7 +201,7 @@ P[outcomes] is a (normalised) projector onto the given {0,1} outcomes. The left 
         		If[
         			AllTrue[codes[[4]], NumericQ, 2],
         			ApplyCircuitInternal[qureg, unpackEncodedCircuit[codes]], 
-        			Echo["Circuit contains non-numerical parameters!", "Error: "]; $Failed
+        			Message[ApplyCircuit::error, "Circuit contains non-numerical parameters!"]; $Failed
         		]
         	]
         (* apply a circuit to get an output state without changing input state. CloneQureg provided by WSTP *)
@@ -200,11 +222,11 @@ P[outcomes] is a (normalised) projector onto the given {0,1} outcomes. The left 
                 codes = codifyCircuit[(circuit /. varVals)]}, 
                 Which[
                     AnyTrue[varOpInds, Length[#]<1&],
-                    Echo["One or more variables were not present in the circuit!", "Error: "]; $Failed,
+                    Message[CalcQuregDerivs::error, "One or more variables were not present in the circuit!"]; $Failed,
                     AnyTrue[varOpInds, Length[#]>1&],
-                    Echo["One or more variables appeared multiple times in the circuit!", "Error: "]; $Failed,
+                    Message[CalcQuregDerivs::error, "One or more variables appeared multiple times in the circuit!"]; $Failed,
                     Not @ AllTrue[codes[[4]], NumericQ, 2],
-                    Echo["The circuit contained variables not assigned values in varVals!", "Error: "]; $Failed,
+                    Message[CalcQuregDerivs::error, "The circuit contained variables not assigned values in varVals!"]; $Failed,
                     True,
                     With[{unitaryGates = Select[
                         Flatten[{varVals[[All,1]], circuit[[varOpInds[[All,1]]]]}, {{2},{1}}], Not[FreeQ[#, U]] &]},
@@ -402,7 +424,7 @@ P[outcomes] is a (normalised) projector onto the given {0,1} outcomes. The left 
         CreateLocalQuESTEnv[fn_:"quest_link"] := If[
             FileExistsQ[fn], 
             Install[fn],  
-            Echo["Local quest_link executable not found!", "Error: "]; $Failed]
+            Message[CreateLocalQuESTEnv::error, "Local quest_link executable not found!"]; $Failed]
         
         CreateDownloadedQuESTEnv[os_String:"MacOS"] := Module[{linkfile},
             If[os == "MacOS",
@@ -410,7 +432,7 @@ P[outcomes] is a (normalised) projector onto the given {0,1} outcomes. The left 
                 Run["chmod +x quest_link"];
                 Install[linkfile],
                 
-                Echo["Only MacOS is currently supported", "Error:"]; $Failed
+                Message[CreateDownloadedQuESTEnv::error, "Only MacOS is currently supported"]; $Failed
             ]
         ]
                     

--- a/QuESTlink.m
+++ b/QuESTlink.m
@@ -325,9 +325,9 @@ P[outcomes] is a (normalised) projector onto the given {0,1} outcomes. The left 
             
         (* compute the expected value of a Pauli product *)
         CalcExpecPauliProd[qureg_Integer, Verbatim[Times][paulis:pattPauli..], workspace_Integer] :=
-            CalcExpecPauliProdInternal[qureg, getOpCode /@ {paulis}[[All,1]], {paulis}[[All,2]], workspace]
+            CalcExpecPauliProdInternal[qureg, workspace, getOpCode /@ {paulis}[[All,1]], {paulis}[[All,2]]]
         CalcExpecPauliProd[qureg_Integer, Subscript[pauli:(X|Y|Z),targ:_Integer], workspace_Integer] :=
-            CalcExpecPauliProdInternal[qureg, getOpcode /@ {pauli}, {targ}, workspace]
+            CalcExpecPauliProdInternal[qureg, workspace, getOpCode /@ {pauli}, {targ}]
             
         (* compute the expected value of a weighted sum of Pauli products *)
         getPauliSumTermCoeff[pauli:pattPauli] = 1;

--- a/makefile
+++ b/makefile
@@ -27,7 +27,7 @@ QUEST_DIR = QuEST
 WSTP_DIR = WSTP
 
 # compiler to use, which should support both C and C++, to be wrapped by GPU/MPI compilers
-COMPILER = gcc-8
+COMPILER = g++-8
 
 # type of above compiler, one of {GNU, INTEL, CLANG}, used for setting compiler flags
 COMPILER_TYPE = GNU
@@ -316,14 +316,14 @@ else ifeq ($(DISTRIBUTED), 1)
 # CPU
 else
 
-  %.o: %.c quest_templates.tm.c
+  %.o: %.c
 	$(COMPILER) -x c $(C_FLAGS) $(QUEST_INCLUDE) -c $<
   %.o: $(QUEST_INNER_DIR)/%.c
 	$(COMPILER) -x c $(C_FLAGS) $(QUEST_INCLUDE) -c $<
   %.o: $(QUEST_COMMON_DIR)/%.c
 	$(COMPILER) -x c $(C_FLAGS) $(QUEST_INCLUDE) -c $<
 	
-  %.o: %.cpp
+  %.o: %.cpp quest_templates.tm.cpp
 	$(COMPILER) $(CPP_FLAGS) $(QUEST_INCLUDE) -c $<
   %.o: $(QUEST_INNER_DIR)/%.cpp
 	$(COMPILER) $(CPP_FLAGS)  -c $<
@@ -371,8 +371,8 @@ else ifeq ($(OS), LINUX)
     PREP = linux_wsprep
 endif
 
-quest_templates.tm.c:
-	$(WSTP_DIR)/$(PREP) quest_templates.tm -o quest_templates.tm.c
+quest_templates.tm.cpp:
+	$(WSTP_DIR)/$(PREP) quest_templates.tm -o quest_templates.tm.cpp
 
 
 
@@ -383,7 +383,7 @@ quest_templates.tm.c:
 .PHONY:		clean veryclean
 clean:
 			/bin/rm -f *.o $(EXE)
-			/bin/rm -f quest_templates.tm.c
+			/bin/rm -f quest_templates.tm.cpp
 veryclean:	clean
 			/bin/rm -f *.h~ *.c~ makefile~
 

--- a/makefile
+++ b/makefile
@@ -27,7 +27,7 @@ QUEST_DIR = QuEST
 WSTP_DIR = WSTP
 
 # compiler to use, which should support both C and C++, to be wrapped by GPU/MPI compilers
-COMPILER = g++-8
+COMPILER = g++
 
 # type of above compiler, one of {GNU, INTEL, CLANG}, used for setting compiler flags
 COMPILER_TYPE = GNU

--- a/quest_link.cpp
+++ b/quest_link.cpp
@@ -1703,6 +1703,9 @@ void internal_calcExpecPauliProd(int quregId, int workspaceId) {
         local_throwExcepIfQuregNotCreated(quregId); // throws 
         local_throwExcepIfQuregNotCreated(workspaceId); // throws
         
+        if (quregId == workspaceId)
+            throw QuESTException("", "qureg and workspace must be different quregs.");
+        
         Qureg qureg = quregs[quregId];
         Qureg workspace = quregs[workspaceId];
         
@@ -1744,6 +1747,9 @@ void internal_calcExpecPauliSum(int quregId, int workspaceId) {
         // ensure quregs exist
         local_throwExcepIfQuregNotCreated(quregId); // throws
         local_throwExcepIfQuregNotCreated(workspaceId); // throws
+        
+        if (quregId == workspaceId)
+            throw QuESTException("", "qureg and workspace must be different quregs.");
         
         Qureg qureg = quregs[quregId];
         Qureg workspace = quregs[workspaceId];
@@ -1848,6 +1854,9 @@ void internal_applyPauliSum(int inId, int outId) {
     try {
         local_throwExcepIfQuregNotCreated(inId); // throws
         local_throwExcepIfQuregNotCreated(outId); // throws
+        
+        if (inId == outId)
+            throw QuESTException("", "inQureg and outQureg must be different quregs.");
         
         Qureg inQureg = quregs[inId];
         Qureg outQureg = quregs[outId];

--- a/quest_link.cpp
+++ b/quest_link.cpp
@@ -35,6 +35,8 @@
 #include <string.h>
 #include <QuEST.h>
 
+#include <string>
+
 /*
  * PI constant needed for (multiControlled) sGate and tGate
  */
@@ -95,10 +97,10 @@ static char errorMsgBuffer[1000];
 /**
  * Reports an error message to MMA without aborting
  */
-void local_sendErrorToMMA(char* err_msg) {
+void local_sendErrorToMMA(std::string err_msg) {
     WSPutFunction(stdlink, "EvaluatePacket", 1);
     WSPutFunction(stdlink, "Echo", 2);
-    WSPutString(stdlink, err_msg);
+    WSPutString(stdlink, err_msg.c_str());
     WSPutString(stdlink, "Error: ");
     WSEndPacket(stdlink);
     WSNextPacket(stdlink);
@@ -114,10 +116,10 @@ void local_sendQuregNotCreatedError(int id) {
     local_sendErrorMsgBufferToMMA();
 }
 
-int local_writeToErrorMsgBuffer(char* msg, ...) {
+int local_writeToErrorMsgBuffer(std::string msg, ...) {
     va_list argp;
     va_start(argp, msg);
-    vsprintf(errorMsgBuffer, msg, argp);
+    vsprintf(errorMsgBuffer, msg.c_str(), argp);
     va_end(argp);
     return 0;
 }
@@ -465,18 +467,18 @@ int wrapper_collapseToOutcome(int id, int qb, int outcome) {
 
 /* circuit execution */
 
-int local_gateUnsupportedError(char* gate) {
+int local_gateUnsupportedError(std::string gate) {
     return local_writeToErrorMsgBuffer("the gate '%s' is not supported.", gate);
 }
 
-int local_gateWrongNumParamsError(char* gate, int wrongNumParams, int rightNumParams) {
+int local_gateWrongNumParamsError(std::string gate, int wrongNumParams, int rightNumParams) {
     return local_writeToErrorMsgBuffer(
         "the gate '%s' accepts %d parameters, but %d were passed.",
         gate, rightNumParams, wrongNumParams);
 }
 
 /* rightNumTargs is a string so that it can be multiple e.g. "1 or 2" */
-int local_gateWrongNumTargsError(char* gate, int wrongNumTargs, char* rightNumTargs) {
+int local_gateWrongNumTargsError(std::string gate, int wrongNumTargs, std::string rightNumTargs) {
     return local_writeToErrorMsgBuffer(
         "the gate '%s' accepts %s, but %d were passed.",
         gate, rightNumTargs, wrongNumTargs);
@@ -505,7 +507,7 @@ int local_isValidProb(int opcode, int numQubits, qreal prob) {
 }
 
 int local_noiseInvalidProbError(int opcode, int numQubits, qreal prob) {
-    char* opStr = "";
+    std::string opStr = "";
     if (opcode == OPCODE_Deph) opStr = "dephasing";
     if (opcode == OPCODE_Depol) opStr = "depolarising";
     if (opcode == OPCODE_Damp) opStr = "amplitude damping";

--- a/quest_templates.tm
+++ b/quest_templates.tm
@@ -6,7 +6,9 @@
 :ArgumentTypes:  { Integer }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`CreateQureg::usage = "CreateQureg[numQubits] returns the id of a newly created statevector."
+:Evaluate: 
+    QuEST`CreateQureg::usage = "CreateQureg[numQubits] returns the id of a newly created statevector.";
+    QuEST`CreateQureg::error = "`1`";
 
 :Begin:
 :Function:       wrapper_createDensityQureg
@@ -15,7 +17,9 @@
 :ArgumentTypes:  { Integer }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`CreateDensityQureg::usage = "CreateDensityQureg[numQubits] returns the id of a newly created density matrix."
+:Evaluate: 
+    QuEST`CreateDensityQureg::usage = "CreateDensityQureg[numQubits] returns the id of a newly created density matrix.";
+    QuEST`CreateDensityQureg::error = "`1`";
 
 :Begin:
 :Function:       wrapper_destroyQureg
@@ -33,7 +37,9 @@
 :ArgumentTypes:  { Integer, Integer }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`CreateQuregs::usage = "CreateQuregs[numQubits, numQuregs] returns a list of ids of a newly created statevectors."
+:Evaluate: 
+    QuEST`CreateQuregs::usage = "CreateQuregs[numQubits, numQuregs] returns a list of ids of a newly created statevectors.";
+    QuEST`CreateQuregs::error = "`1`";
 
 :Begin:
 :Function:       callable_createDensityQuregs
@@ -42,7 +48,9 @@
 :ArgumentTypes:  { Integer, Integer }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`CreateDensityQuregs::usage = "CreateDensityQuregs[numQubits, numQuregs] returns a list of ids of a newly created density matrices."
+:Evaluate: 
+    QuEST`CreateDensityQuregs::usage = "CreateDensityQuregs[numQubits, numQuregs] returns a list of ids of a newly created density matrices.";
+    QuEST`CreateDensityQuregs::error = "`1`";
 
 
 
@@ -54,7 +62,9 @@
 :ArgumentTypes:  { Integer }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`InitZeroState::usage = "InitZeroState[qureg] sets the qureg to state |0> (and returns the qureg id)."
+:Evaluate: 
+    QuEST`InitZeroState::usage = "InitZeroState[qureg] sets the qureg to state |0> (and returns the qureg id).";
+    QuEST`InitZeroState::error = "`1`";
 
 :Begin:
 :Function:       wrapper_initPlusState
@@ -63,7 +73,9 @@
 :ArgumentTypes:  { Integer  }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`InitPlusState::usage = "InitPlusState[qureg] sets the qureg to state |+> (and returns the qureg id)."
+:Evaluate: 
+    QuEST`InitPlusState::usage = "InitPlusState[qureg] sets the qureg to state |+> (and returns the qureg id).";
+    QuEST`InitPlusState::error = "`1`";
 
 :Begin:
 :Function:       wrapper_initClassicalState
@@ -72,7 +84,9 @@
 :ArgumentTypes:  { Integer, Integer }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`InitClassicalState::usage = "InitClassicalState[qureg, ind] sets the qureg to basis state |ind> (and returns the qureg id)."
+:Evaluate: 
+    QuEST`InitClassicalState::usage = "InitClassicalState[qureg, ind] sets the qureg to basis state |ind> (and returns the qureg id).";
+    QuEST`InitClassicalState::error = "`1`";
 
 :Begin:
 :Function:       wrapper_initPureState
@@ -81,7 +95,9 @@
 :ArgumentTypes:  { Integer, Integer }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`InitPureState::usage = "InitPureState[targetQureg, pureQureg] puts targetQureg (statevec or density matrix) into the pureQureg (statevec) state (and returns the targetQureg id)."
+:Evaluate:
+    QuEST`InitPureState::usage = "InitPureState[targetQureg, pureQureg] puts targetQureg (statevec or density matrix) into the pureQureg (statevec) state (and returns the targetQureg id).";
+    QuEST`InitPureState::error = "`1`";
 
 :Begin:
 :Function:       wrapper_initStateFromAmps
@@ -90,7 +106,9 @@
 :ArgumentTypes:  { Integer, RealList, RealList }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`InitStateFromAmps::usage = "InitStateFromAmps[qureg, reals, imags] initialises the given qureg to have the supplied amplitudes (and returns the qureg id)."
+:Evaluate: 
+    QuEST`InitStateFromAmps::usage = "InitStateFromAmps[qureg, reals, imags] initialises the given qureg to have the supplied amplitudes (and returns the qureg id).";
+    QuEST`InitStateFromAmps::error = "`1`";
 
 :Begin:
 :Function:       wrapper_cloneQureg
@@ -99,7 +117,9 @@
 :ArgumentTypes:  { Integer, Integer }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`CloneQureg::usage = "CloneQureg[dest, source] sets dest to be a copy of source."
+:Evaluate:
+    QuEST`CloneQureg::usage = "CloneQureg[dest, source] sets dest to be a copy of source.";
+    QuEST`CloneQureg::error = "`1`";
 
 :Begin:
 :Function:       internal_getAmp
@@ -117,7 +137,9 @@
 :ArgumentTypes:  { Integer }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`IsDensityMatrix::usage = "IsDensityMatrix[qureg] returns 0 or 1 to indicate whether qureg is a statevector or density matrix (respectively)."
+:Evaluate: 
+    QuEST`IsDensityMatrix::usage = "IsDensityMatrix[qureg] returns 0 or 1 to indicate whether qureg is a statevector or density matrix (respectively).";
+    QuEST`IsDensityMatrix::error = "`1`";
 
 
 
@@ -129,7 +151,9 @@
 :ArgumentTypes:  { Integer, Integer, Real }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`MixDepolarising::usage = "MixDepolarising[qureg, qubit, prob] adds depolarising noise to density matrix qureg."
+:Evaluate: 
+    QuEST`MixDepolarising::usage = "MixDepolarising[qureg, qubit, prob] adds depolarising noise to density matrix qureg.";
+    QuEST`MixDepolarising::error = "`1`";
 
 :Begin:
 :Function:       wrapper_mixTwoQubitDepolarising
@@ -138,7 +162,9 @@
 :ArgumentTypes:  { Integer, Integer, Integer, Real }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`MixTwoQubitDepolarising::usage = "MixTwoQubitDepolarising[qureg, qb1, qb2 prob] adds depolarising noise to density matrix qureg."
+:Evaluate: 
+    QuEST`MixTwoQubitDepolarising::usage = "MixTwoQubitDepolarising[qureg, qb1, qb2 prob] adds depolarising noise to density matrix qureg.";
+    QuEST`MixTwoQubitDepolarising::error = "`1`";
 
 :Begin:
 :Function:       wrapper_mixDephasing
@@ -147,7 +173,9 @@
 :ArgumentTypes:  { Integer, Integer, Real }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`MixDephasing::usage = "MixDephasing[qureg, qubit, prob] adds dephasing noise to density matrix qureg."
+:Evaluate: 
+    QuEST`MixDephasing::usage = "MixDephasing[qureg, qubit, prob] adds dephasing noise to density matrix qureg.";
+    QuEST`MixDephasing::error = "`1`";
 
 :Begin:
 :Function:       wrapper_mixTwoQubitDephasing
@@ -156,7 +184,9 @@
 :ArgumentTypes:  { Integer, Integer, Integer, Real }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`MixTwoQubitDephasing::usage = "MixTwoQubitDephasing[qureg, qb1, qb2 prob] adds dephasing noise to density matrix qureg."
+:Evaluate: 
+    QuEST`MixTwoQubitDephasing::usage = "MixTwoQubitDephasing[qureg, qb1, qb2 prob] adds dephasing noise to density matrix qureg.";
+    QuEST`MixTwoQubitDephasing::error = "`1`";
 
 :Begin:
 :Function:       wrapper_mixDamping
@@ -165,7 +195,9 @@
 :ArgumentTypes:  { Integer, Integer, Real }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`MixDamping::usage = "MixDamping[qureg, qubit, prob] applies amplitude damping with the given decay probability to density matrix qureg."
+:Evaluate: 
+    QuEST`MixDamping::usage = "MixDamping[qureg, qubit, prob] applies amplitude damping with the given decay probability to density matrix qureg.";
+    QuEST`MixDamping::error = "`1`";
 
 
 
@@ -177,7 +209,9 @@
 :ArgumentTypes:  { Integer, Integer, Integer }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`CalcProbOfOutcome::usage = "CalcProbOfOutcome[qureg, qubit, outcome] returns the probability of measuring qubit in the given outcome."
+:Evaluate: 
+    QuEST`CalcProbOfOutcome::usage = "CalcProbOfOutcome[qureg, qubit, outcome] returns the probability of measuring qubit in the given outcome.";
+    QuEST`CalcProbOfOutcome::error = "`1`";
 
 :Begin:
 :Function:       wrapper_calcFidelity
@@ -186,7 +220,9 @@
 :ArgumentTypes:  { Integer, Integer }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`CalcFidelity::usage = "CalcFidelity[qureg1, qureg2] returns the fidelity between the given states."
+:Evaluate: 
+    QuEST`CalcFidelity::usage = "CalcFidelity[qureg1, qureg2] returns the fidelity between the given states.";
+    QuEST`CalcFidelity::error = "`1`";
 
 :Begin:
 :Function:       wrapper_calcInnerProduct
@@ -195,7 +231,9 @@
 :ArgumentTypes:  { Integer, Integer }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`CalcInnerProduct::usage = "CalcInnerProduct[qureg1, qureg2] returns the complex inner product between the given states."
+:Evaluate: 
+    QuEST`CalcInnerProduct::usage = "CalcInnerProduct[qureg1, qureg2] returns the complex inner product between the given states.";
+    QuEST`CalcInnerProduct::error = "`1`";
 
 :Begin:
 :Function:       wrapper_calcDensityInnerProduct
@@ -204,7 +242,9 @@
 :ArgumentTypes:  { Integer, Integer }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`CalcDensityInnerProduct::usage = "CalcDensityInnerProduct[qureg1, qureg2] returns the real Hilbert schmidt scalar product between two given density matrices."
+:Evaluate: 
+    QuEST`CalcDensityInnerProduct::usage = "CalcDensityInnerProduct[qureg1, qureg2] returns the real Hilbert schmidt scalar product between two given density matrices.";
+    QuEST`CalcDensityInnerProduct::error = "`1`";
 
 :Begin:
 :Function:       wrapper_calcPurity
@@ -213,7 +253,9 @@
 :ArgumentTypes:  { Integer }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`CalcPurity::usage = "CalcPurity[qureg] returns the purity of the given density matrix."
+:Evaluate: 
+    QuEST`CalcPurity::usage = "CalcPurity[qureg] returns the purity of the given density matrix.";
+    QuEST`CalcPurity::error = "`1`";
 
 :Begin:
 :Function:       wrapper_calcTotalProb
@@ -222,7 +264,9 @@
 :ArgumentTypes:  { Integer }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`CalcTotalProb::usage = "CalcTotalProb[qureg] returns the total probability (normalisation) of the statevector (sum of abs-squared of amplitudes) or density matrix (trace), which should be 1."
+:Evaluate: 
+    QuEST`CalcTotalProb::usage = "CalcTotalProb[qureg] returns the total probability (normalisation) of the statevector (sum of abs-squared of amplitudes) or density matrix (trace), which should be 1.";
+    QuEST`CalcTotalProb::error = "`1`";
 
 :Begin:
 :Function:       wrapper_calcHilbertSchmidtDistance
@@ -231,7 +275,9 @@
 :ArgumentTypes:  { Integer, Integer }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`CalcHilbertSchmidtDistance::usage = "CalcHilbertSchmidtDistance[qureg1, qureg2] returns the Hilbert-Schmidt distance (Frobenius norm of the difference) between the given density matrices."
+:Evaluate: 
+    QuEST`CalcHilbertSchmidtDistance::usage = "CalcHilbertSchmidtDistance[qureg1, qureg2] returns the Hilbert-Schmidt distance (Frobenius norm of the difference) between the given density matrices.";
+    QuEST`CalcHilbertSchmidtDistance::error = "`1`";
 
 :Begin:
 :Function:       internal_calcQuregDerivs
@@ -326,13 +372,13 @@
 :Evaluate: QuEST`Private`CalcPauliSumMatrixInternal::usage = "CalcPauliSumMatrixInternal[numQubits, termCoeffs, allPauliCodes, allPauliTargets, numPaulisPerTerm] returns the action of applying the given sum of Pauli products (specified as flat lists) to every basis state."
 
 :Begin:
-:Function:       internal_getStateVec
-:Pattern:        QuEST`Private`GetStateVecInternal[qureg_Integer]
+:Function:       internal_getQuregMatrix
+:Pattern:        QuEST`Private`GetQuregMatrixInternal[qureg_Integer]
 :Arguments:      { qureg }
 :ArgumentTypes:  { Integer }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`Private`GetStateVecInternal::usage = "GetStateVecInternal[qureg] returns the underlying statevector associated with the given qureg (flat, even for density matrices)."
+:Evaluate: QuEST`Private`GetQuregMatrixInternal::usage = "GetQuregMatrixInternal[qureg] returns the underlying statevector associated with the given qureg (flat, even for density matrices)."
 
 :Begin:
 :Function:       internal_setWeightedQureg
@@ -350,7 +396,9 @@
 :ArgumentTypes:  { Integer, Integer, Integer }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`CollapseToOutcome::usage = "CollapseToOutcome[qureg, qubit, outcome] forces the target qubit to collapse to the given outcome."
+:Evaluate: 
+    QuEST`CollapseToOutcome::usage = "CollapseToOutcome[qureg, qubit, outcome] forces the target qubit to collapse to the given outcome.";
+    QuEST`CollapseToOutcome::error = "`1`";
 
 
 
@@ -362,7 +410,9 @@
 :ArgumentTypes:  { }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`DestroyAllQuregs::usage = "DestroyAllQuregs[] destroys all remote quregs."
+:Evaluate: 
+    QuEST`DestroyAllQuregs::usage = "DestroyAllQuregs[] destroys all remote quregs.";
+    QuEST`DestroyAllQuregs::error = "`1`";
 
 :Begin:
 :Function:       callable_getAllQuregs
@@ -371,4 +421,6 @@
 :ArgumentTypes:  { }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`GetAllQuregs::usage = "GetAllQuregs[] returns all active quregs."
+:Evaluate: 
+    QuEST`GetAllQuregs::usage = "GetAllQuregs[] returns all active quregs.";
+    QuEST`GetAllQuregs::error = "`1`";

--- a/quest_templates.tm
+++ b/quest_templates.tm
@@ -4,7 +4,7 @@
 :Pattern:        QuEST`CreateQureg[numQubits_Integer]
 :Arguments:      { numQubits }
 :ArgumentTypes:  { Integer }
-:ReturnType:     Integer
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`CreateQureg::usage = "CreateQureg[numQubits] returns the id of a newly created statevector."
 
@@ -13,7 +13,7 @@
 :Pattern:        QuEST`CreateDensityQureg[numQubits_Integer]
 :Arguments:      { numQubits }
 :ArgumentTypes:  { Integer }
-:ReturnType:     Integer
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`CreateDensityQureg::usage = "CreateDensityQureg[numQubits] returns the id of a newly created density matrix."
 
@@ -22,7 +22,7 @@
 :Pattern:        QuEST`Private`DestroyQuregInternal[id_Integer]
 :Arguments:      { id }
 :ArgumentTypes:  { Integer }
-:ReturnType:     Integer
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`Private`DestroyQuregInternal::usage = "DestroyQuregInternal[numQubits] frees the memory of the qureg associated with the given id."
 
@@ -52,7 +52,7 @@
 :Pattern:        QuEST`InitZeroState[qureg_Integer]
 :Arguments:      { qureg }
 :ArgumentTypes:  { Integer }
-:ReturnType:     Integer
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`InitZeroState::usage = "InitZeroState[qureg] sets the qureg to state |0> (and returns the qureg id)."
 
@@ -61,7 +61,7 @@
 :Pattern:        QuEST`InitPlusState[qureg_Integer]
 :Arguments:      { qureg }
 :ArgumentTypes:  { Integer  }
-:ReturnType:     Integer
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`InitPlusState::usage = "InitPlusState[qureg] sets the qureg to state |+> (and returns the qureg id)."
 
@@ -70,7 +70,7 @@
 :Pattern:        QuEST`InitClassicalState[qureg_Integer, state_Integer]
 :Arguments:      { qureg, state }
 :ArgumentTypes:  { Integer, Integer }
-:ReturnType:     Integer
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`InitClassicalState::usage = "InitClassicalState[qureg, ind] sets the qureg to basis state |ind> (and returns the qureg id)."
 
@@ -79,7 +79,7 @@
 :Pattern:        QuEST`InitPureState[targetQureg_Integer, pureQureg_Integer]
 :Arguments:      { targetQureg, pureQureg }
 :ArgumentTypes:  { Integer, Integer }
-:ReturnType:     Integer
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`InitPureState::usage = "InitPureState[targetQureg, pureQureg] puts targetQureg (statevec or density matrix) into the pureQureg (statevec) state (and returns the targetQureg id)."
 
@@ -88,7 +88,7 @@
 :Pattern:        QuEST`InitStateFromAmps[qureg_Integer, reals_List, imags_List]
 :Arguments:      { qureg, reals, imags }
 :ArgumentTypes:  { Integer, RealList, RealList }
-:ReturnType:     Integer
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`InitStateFromAmps::usage = "InitStateFromAmps[qureg, reals, imags] initialises the given qureg to have the supplied amplitudes (and returns the qureg id)."
 
@@ -97,7 +97,7 @@
 :Pattern:        QuEST`CloneQureg[target_Integer, source_Integer]
 :Arguments:      { target, source }
 :ArgumentTypes:  { Integer, Integer }
-:ReturnType:     Integer
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`CloneQureg::usage = "CloneQureg[dest, source] sets dest to be a copy of source."
 
@@ -127,7 +127,7 @@
 :Pattern:        QuEST`MixDepolarising[qureg_Integer, qb_Integer, prob_Real]
 :Arguments:      { qureg, qb, prob }
 :ArgumentTypes:  { Integer, Integer, Real }
-:ReturnType:     Integer
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`MixDepolarising::usage = "MixDepolarising[qureg, qubit, prob] adds depolarising noise to density matrix qureg."
 
@@ -136,7 +136,7 @@
 :Pattern:        QuEST`MixTwoQubitDepolarising[qureg_Integer, qb1_Integer, qb2_Integer, prob_Real]
 :Arguments:      { qureg, qb1, qb2, prob }
 :ArgumentTypes:  { Integer, Integer, Integer, Real }
-:ReturnType:     Integer
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`MixTwoQubitDepolarising::usage = "MixTwoQubitDepolarising[qureg, qb1, qb2 prob] adds depolarising noise to density matrix qureg."
 
@@ -145,7 +145,7 @@
 :Pattern:        QuEST`MixDephasing[qureg_Integer, qb_Integer, prob_Real]
 :Arguments:      { qureg, qb, prob }
 :ArgumentTypes:  { Integer, Integer, Real }
-:ReturnType:     Integer
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`MixDephasing::usage = "MixDephasing[qureg, qubit, prob] adds dephasing noise to density matrix qureg."
 
@@ -154,7 +154,7 @@
 :Pattern:        QuEST`MixTwoQubitDephasing[qureg_Integer, qb1_Integer, qb2_Integer, prob_Real]
 :Arguments:      { qureg, qb1, qb2, prob }
 :ArgumentTypes:  { Integer, Integer, Integer, Real }
-:ReturnType:     Integer
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`MixTwoQubitDephasing::usage = "MixTwoQubitDephasing[qureg, qb1, qb2 prob] adds dephasing noise to density matrix qureg."
 
@@ -163,7 +163,7 @@
 :Pattern:        QuEST`MixDamping[qureg_Integer, qb_Integer, prob_Real]
 :Arguments:      { qureg, qb, prob }
 :ArgumentTypes:  { Integer, Integer, Real }
-:ReturnType:     Integer
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`MixDamping::usage = "MixDamping[qureg, qubit, prob] applies amplitude damping with the given decay probability to density matrix qureg."
 
@@ -175,7 +175,7 @@
 :Pattern:        QuEST`CalcProbOfOutcome[qureg_Integer, qb_Integer, outcome_Integer]
 :Arguments:      { qureg, qb, outcome }
 :ArgumentTypes:  { Integer, Integer, Integer }
-:ReturnType:     Real
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`CalcProbOfOutcome::usage = "CalcProbOfOutcome[qureg, qubit, outcome] returns the probability of measuring qubit in the given outcome."
 
@@ -184,7 +184,7 @@
 :Pattern:        QuEST`CalcFidelity[qureg1_Integer, qureg2_Integer]
 :Arguments:      { qureg1, qureg2 }
 :ArgumentTypes:  { Integer, Integer }
-:ReturnType:     Real
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`CalcFidelity::usage = "CalcFidelity[qureg1, qureg2] returns the fidelity between the given states."
 
@@ -211,7 +211,7 @@
 :Pattern:        QuEST`CalcPurity[qureg_Integer]
 :Arguments:      { qureg }
 :ArgumentTypes:  { Integer }
-:ReturnType:     Real
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`CalcPurity::usage = "CalcPurity[qureg] returns the purity of the given density matrix."
 
@@ -220,7 +220,7 @@
 :Pattern:        QuEST`CalcTotalProb[qureg_Integer]
 :Arguments:      { qureg }
 :ArgumentTypes:  { Integer }
-:ReturnType:     Real
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`CalcTotalProb::usage = "CalcTotalProb[qureg] returns the total probability (normalisation) of the statevector (sum of abs-squared of amplitudes) or density matrix (trace), which should be 1."
 
@@ -229,7 +229,7 @@
 :Pattern:        QuEST`CalcHilbertSchmidtDistance[qureg1_Integer, qureg2_Integer]
 :Arguments:      { qureg1, qureg2 }
 :ArgumentTypes:  { Integer, Integer }
-:ReturnType:     Real
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`CalcHilbertSchmidtDistance::usage = "CalcHilbertSchmidtDistance[qureg1, qureg2] returns the Hilbert-Schmidt distance (Frobenius norm of the difference) between the given density matrices."
 
@@ -294,7 +294,7 @@
 :Pattern:        QuEST`Private`CalcExpecPauliProdInternal[qureg_Integer, workspace_Integer, paulis_List, targets_List]
 :Arguments:      { qureg, workspace, paulis, targets }
 :ArgumentTypes:  { Integer, Integer, Manual }
-:ReturnType:     Real
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`Private`CalcExpecPauliProdInternal::usage = "CalcExpecPauliProdInternal[qureg, workspace, paulis, targets] returns the expected value of the qureg under the given pauli product. workspace must be a Qureg of equal dimensions to qureg."
 
@@ -303,7 +303,7 @@
 :Pattern:        QuEST`Private`CalcExpecPauliSumInternal[qureg_Integer, workspace_Integer, termCoeffs_List, allPauliCodes_List, allPauliTargets_List, numPaulisPerTerm_List]
 :Arguments:      { qureg, workspace, termCoeffs, allPauliCodes, allPauliTargets, numPaulisPerTerm }
 :ArgumentTypes:  { Integer, Integer, Manual }
-:ReturnType:     Real
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`Private`CalcExpecPauliSumInternal::usage = "CalcExpecPauliSumInternal[qureg, workspace, termCoeffs, allPauliCodes, allPauliTargets, numPaulisPerTerm] returns the expected value of the qureg under the given sum of Pauli products, specified as flat lists. workspace must be a Qureg of equal dimensions to qureg."
 
@@ -312,7 +312,7 @@
 :Pattern:        QuEST`Private`ApplyPauliSumInternal[inQureg_Integer, outQureg_Integer, termCoeffs_List, allPauliCodes_List, allPauliTargets_List, numPaulisPerTerm_List]
 :Arguments:      { inQureg, outQureg, termCoeffs, allPauliCodes, allPauliTargets, numPaulisPerTerm }
 :ArgumentTypes:  { Integer, Integer, Manual }
-:ReturnType:     Integer
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`Private`ApplyPauliSumInternal::usage = "ApplyPauliSumInternal[inQureg, outQureg, termCoeffs, allPauliCodes, allPauliTargets, numPaulisPerTerm] modifies outQureg under the given sum of Pauli products, specified as flat lists. inQureg and outQureg must have the same type and equal dimensions."
 
@@ -339,7 +339,7 @@
 :Pattern:        QuEST`Private`SetWeightedQuregInternal[facRe1_Real,facIm1_Real,qureg1_Integer, facRe2_Real,facIm2_Real,qureg2_Integer, facReOut_Real,facImOut_Real,quregOut_Integer]
 :Arguments:      { facRe1,facIm1,qureg1, facRe2,facIm2,qureg2, facReOut,facImOut,quregOut }
 :ArgumentTypes:  { Real, Real, Integer, Real, Real, Integer, Real, Real, Integer }
-:ReturnType:     Integer
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`Private`SetWeightedQuregInternal::usage = "SetWeightedQuregInternal[facRe1,facIm1,qureg1, facRe2,facIm2,qureg2, facReOut,facImOut,quregOut] modifies quregOut to become (fac1 qureg1 + fac2 qureg2 + facOut qurgeOut)."
 
@@ -348,7 +348,7 @@
 :Pattern:        QuEST`CollapseToOutcome[qureg_Integer, qubit_Integer, outcome_Integer]
 :Arguments:      { qureg, qubit, outcome }
 :ArgumentTypes:  { Integer, Integer, Integer }
-:ReturnType:     Integer
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`CollapseToOutcome::usage = "CollapseToOutcome[qureg, qubit, outcome] forces the target qubit to collapse to the given outcome."
 
@@ -360,7 +360,7 @@
 :Pattern:        QuEST`DestroyAllQuregs[]
 :Arguments:      { }
 :ArgumentTypes:  { }
-:ReturnType:     Integer
+:ReturnType:     Manual
 :End:
 :Evaluate: QuEST`DestroyAllQuregs::usage = "DestroyAllQuregs[] destroys all remote quregs."
 


### PR DESCRIPTION
- core QuEST validation failures are now caught as exceptions, and don't kill QuESTlink
- errors are now reported to Mathematica as `Message` (canonical way to present errors), no longer as `Echo` - they're now red, and can be stack-traced!
- fixes all memory leaks
- fixes all pipeline crashes
- removes all bespoke error-codes from functions, greatly simplifying code
- increased catching of user-errors (e.g. fixes #54, #62, and qureg-creation checking now done in all functions)
- removes overlap of core-QuEST and QuESTlink validation (e.g. removes #36)
- QuESTlink is now C++11, making further development significantly easier
