### PR TITLE
allowed Id (in any form) in ApplyCircuit

### DIFF
--- a/Link/QuESTlink.m
+++ b/Link/QuESTlink.m
@@ -159,7 +159,7 @@ P[outcomes] is a (normalised) projector onto the given {0,1} outcomes. The left 
     PackageExport[G]
     G::usage = "G[phi] applies a global phase rotation of phi, by premultiplying Exp[i phi]."
     PackageExport[Id]
-    Id::usage = "Id is an identity gate which effects no change, but can be used for forcing gate alignment in DrawCircuit."
+    Id::usage = "Id is an identity gate which effects no change, but can be used for forcing gate alignment in DrawCircuit, or as an alternative to removing gates in ApplyCircuit."
  
     Begin["`Private`"]
     
@@ -174,7 +174,7 @@ P[outcomes] is a (normalised) projector onto the given {0,1} outcomes. The left 
                
         (* opcodes *)
         getOpCode[gate_] :=
-	        gate /. {H->0,X->1,Y->2,Z->3,Rx->4,Ry->5,Rz->6,R->7,S->8,T->9,U->10,Deph->11,Depol->12,Damp->13,SWAP->14,M->15,P->16,Kraus->17,G->18,_->-1}
+	        gate /. {H->0,X->1,Y->2,Z->3,Rx->4,Ry->5,Rz->6,R->7,S->8,T->9,U->10,Deph->11,Depol->12,Damp->13,SWAP->14,M->15,P->16,Kraus->17,G->18,Id->19,_->-1}
         
         (* convert MMA matrix to a flat format which can be embedded in the circuit param list *)
         codifyMatrix[matr_] :=
@@ -211,7 +211,7 @@ P[outcomes] is a (normalised) projector onto the given {0,1} outcomes. The left 
 
         (* converting gate sequence to code lists: {opcodes, ctrls, targs, params} *)
         codifyCircuit[circuit_List] :=
-        	(circuit /. Subscript[Id,__] -> Sequence[]) /. gatePatterns // Transpose
+        	circuit /. gatePatterns // Transpose
         codifyCircuit[circuit_] :=
             codifyCircuit @ {circuit}
             

--- a/Link/quest_link.cpp
+++ b/Link/quest_link.cpp
@@ -67,6 +67,7 @@
 #define OPCODE_P 16
 #define OPCODE_Kraus 17
 #define OPCODE_G 18
+#define OPCODE_Id 19
 
 /*
  * Codes for dynamically updating kernel variables, to indicate progress 
@@ -1282,6 +1283,10 @@ void local_applyGates(
                     setWeightedQureg(zero, qureg, zero, qureg, fac, qureg); // throws
                 }
             }
+                break;
+                
+            case OPCODE_Id :
+                // any numCtrls, numParams and numTargs is valid; all do nothing!
                 break;
                 
             default:            


### PR DESCRIPTION
Id can now have
- any number of targets
- any number of controls
- any number of parameters

and still effect identity. This is useful for removing gates from a circuit, in lieu of replacing them with Sequence[]