### PR TITLE
patched GetAllQuregs

### DIFF
--- a/Link/quest_link.cpp
+++ b/Link/quest_link.cpp
@@ -388,7 +388,7 @@ void callable_getAllQuregs(void) {
     
     // collect all created quregs
     int numQuregs = 0;
-    int* idList = (int*) malloc(quregs.size());
+    int* idList = (int*) malloc(quregs.size() * sizeof *idList);
     for (size_t id=0; id < quregs.size(); id++)
         if (quregIsCreated[id])
             idList[numQuregs++] = id;


### PR DESCRIPTION
GetAllQuregs would cause a seg-fault (and QuESTlink to crash) when the ratio of active Quregs to the capacity of the global 'quregs' vector was larger than 1/sizeof(int).