### PR TITLE
extending ApplyPhaseFunc

### DIFF
--- a/Link/QuESTlink.m
+++ b/Link/QuESTlink.m
@@ -70,8 +70,8 @@ ApplyPhaseFunc[qureg, {qubits, ...}, FuncName, overrides] first consults the ove
     DestroyQureg::usage = "DestroyQureg[qureg] destroys the qureg associated with the given ID. If qureg is a Symbol, it will additionally be cleared."
     DestroyQureg::error = "`1`"
     
-    GetAmp::usage = "GetAmp[qureg, index] returns the complex amplitude of the state-vector qureg at the given index.
-GetAmp[qureg, row, col] returns the complex amplitude of the density-matrix qureg at index [row, col]."
+    GetAmp::usage = "GetAmp[qureg, index] returns the complex amplitude of the state-vector qureg at the given index, indexing from 0.
+GetAmp[qureg, row, col] returns the complex amplitude of the density-matrix qureg at index [row, col], indexing from [0,0]."
     GetAmp::error = "`1`"
     
     GetQuregMatrix::usage = "GetQuregMatrix[qureg] returns the state-vector or density matrix associated with the given qureg."

--- a/Link/QuESTlink.m
+++ b/Link/QuESTlink.m
@@ -60,6 +60,7 @@ ApplyPhaseFunc[qureg, {qubits, ...}, FuncName] evaluates a specific named multi-
     \[Bullet] \"InverseNorm\" evaluates 1/Sqrt[x^2 + y^2 + ...]. This requires overriding the phase of index {0,0...} to avoid divergence.
     \[Bullet] {\"ScaledNorm\", coeff} evaluates coeff Sqrt[x^2 + y^2 + ...]
     \[Bullet] {\"ScaledInverseNorm\", coeff} evaluates coeff/Sqrt[x^2 + y^2 + ...]
+    \[Bullet] {\"ScaledProduct\", coeff} evaluates coeff * x * y * ...
 ApplyPhaseFunc[qureg, {qubits, ...}, FuncName, overrides] first consults the overrides."
     ApplyPhaseFunc::error = "`1`"
 
@@ -784,7 +785,8 @@ P[outcomes] is a (normalised) projector onto the given {0,1} outcomes. The left 
             "Norm" -> 0,
             "InverseNorm" -> 1,
             "ScaledNorm" -> 2,
-            "ScaledInverseNorm" -> 3
+            "ScaledInverseNorm" -> 3,
+            "ScaledProduct" -> 4
         };
         ApplyPhaseFunc[qureg_Integer, regs:{{_Integer..}..}, (_String|{_String, (_?Internal`RealValuedNumericQ...)}), phaseOverrides:{({_Integer..} -> _?Internal`RealValuedNumericQ) ..}] /; (
             Not[Equal @@ Length /@ phaseOverrides[[All,1]]] || Length[regs] =!= Length @ phaseOverrides[[1,1]]) :=

--- a/Link/QuESTlink.m
+++ b/Link/QuESTlink.m
@@ -48,22 +48,23 @@ CalcDensityInnerProducts[rhoId, omegaIds] returns a real vector with i-th elemen
     ApplyPauliSum::error = "`1`"
     
     ApplyPhaseFunc::usage = "ApplyPhaseFunc[qureg, qubits, f[r], r] multiplies a phase factor e^(i f[r]) onto each amplitude in qureg, where r is substituted with the index of each basis state as informed by the list of qubits (ordered least to most significant), and optional argument BitEncoding.
-ApplyPhaseFunc[qureg, qubits, f[r], r, overrides] first consults whether a basis state's index is included in the list of rules in overrides {index -> phase}, and if present, uses the prescribed phase in lieu of evaluating f[index].
-    \[Bullet] qubits is a list of which qubits to include in the determination of the index r for each basis state. qubits={0,1,2} implies the canonical indexing of basis states in a 3-qubit register.
-    \[Bullet] f[r] must be an exponential polynomial of r, of the form sum_i a_j r^(p_j) where a_j and p_j can be any real number (including negative and fractional).
-    \[Bullet] f[r] must evaluate to a real number for every basis state index informed by qubits, unless overriden.
+\[Bullet] qubits is a list of which qubits to include in the determination of the index r for each basis state. For example, qubits={0,1,2} implies the canonical indexing of basis states in a 3-qubit register.
+\[Bullet] f[r] must be an exponential polynomial of r, of the form sum_i a_j r^(p_j) where a_j and p_j can be any real number (including negative and fractional).
+\[Bullet] f[r] must evaluate to a real number for every basis state index informed by qubits, unless overriden via optional argument PhaseOverrides.
 ApplyPhaseFunc[qureg, {qubits, ...}, f[x,y,...], {x,y,...}] evaluates a multi-variable exponential-polynomial phase function, where each variable corresponds to a sub-register of qubits.
-ApplyPhaseFunc[qureg, {qubits, ...}, f[x,y,...], {x,y,...}, overrides] first consults whether tuple of sub-register indices already exists in the list of phase overrides.
-    \[Bullet] each element of overrides must have format {x0,y0,...} -> phase0.
 ApplyPhaseFunc[qureg, {qubits, ...}, FuncName] evaluates a specific named multi-variable function to determine the phase. These are:
     \[Bullet] \"Norm\" evaluates Sqrt[x^2 + y^2 + ...]
-    \[Bullet] \"InverseNorm\" evaluates 1/Sqrt[x^2 + y^2 + ...]. This requires overriding the phase of index {0,0...} to avoid divergence.
+    \[Bullet] \"InverseNorm\" evaluates 1/Sqrt[x^2 + y^2 + ...]. 
+        This requires overriding the phase of index {0,0...} to avoid divergence.
     \[Bullet] {\"ScaledNorm\", coeff} evaluates coeff Sqrt[x^2 + y^2 + ...]
     \[Bullet] {\"ScaledInverseNorm\", coeff} evaluates coeff/Sqrt[x^2 + y^2 + ...]
     \[Bullet] {\"ScaledProduct\", coeff} evaluates coeff * x * y * ...
-ApplyPhaseFunc[qureg, {qubits, ...}, FuncName, overrides] first consults the overrides.
+ApplyPhaseFunc accepts optional arguments BitEncoding and PhaseOverrides.
+ApplyPhaseFunc[... PhaseOverrides -> rules] first consults whether a basis state's index is included in the list of rules {index -> phase}, and if present, uses the prescribed phase in lieu of evaluating f[index].
+    For multi-variable functions, each index must be a tuple.
 ApplyPhaseFunc[..., BitEncoding -> \"Unsigned\"] interprets each sub-register state as an unsigned binary integer, in {0, ..., 2^numQubits-1}
-ApplyPhaseFunc[..., BitEncoding -> \"TwosComplement\"] interprets each sub-register state as a two's complement signed integer in {-2^(N-1), ..., +2^(N-1)-1}, where N is the number of qubits (including the sign qubit)."
+ApplyPhaseFunc[..., BitEncoding -> \"TwosComplement\"] interprets each sub-register state as a two's complement signed integer in {-2^(N-1), ..., +2^(N-1)-1}, where N is the number of qubits (including the sign qubit).
+See ?BitEncoding and ?PhaseOverrides."
     ApplyPhaseFunc::error = "`1`"
 
     CalcPauliSumMatrix::usage = "CalcPauliSumMatrix[pauliSum] returns the matrix form of the given weighted sum of Pauli operators. The number of qubits is assumed to be the largest Pauli target."
@@ -217,8 +218,13 @@ DistinguishedStyles -> Automatic will colour the groups by sampling ColorData[\"
     ReplaceAliases::usage = "Optional argument to GetCircuitSchedule and InsertCircuitNoise, specifying (True or False) whether to substitute the device specification's alias operators in the output (including in gates and active/passive noise). 
 This is False by default, but must be True to pass the output circuits to (for example) ApplyCircuit which don't recognise the alias.
 Note if ReplaceAliases -> True, then the output of GetCircuitSchedule might not be compatible as an input to InsertCircuitNoise."
+
+    PhaseOverrides::usage = "Optional argument to ApplyPhaseFunc, specifying overriding values of the phase function for specific sub-register basis states. This can be used to avoid divergences in the phase function.
+For a single-variable phase function, like ApplyPhaseFunc[..., x^2, x], the option must have form PhaseOverrides -> {integer -> real, ...}, where 'integer' is the basis state index of which to override the phase.
+For a multi-variable phase function, like ApplyPhaseFunc[..., x^2+y^2, {x,y}], the option must have form PhaseOverrides -> {{integer, integer} -> real, ...}, where the basis state indices are specified as a tuple {x,y}.
+Note under BitEncoding -> \"TwosComplement\", basis state indices can be negative."
     
-    BitEncoding::usage = "Optional argument to ApplyPhaseFunc, specifying how the values of sub-register basis states are encoded in bits.
+    BitEncoding::usage = "Optional argument to ApplyPhaseFunc, specifying how the values of sub-register basis states are encoded in (qu)bits.
 BitEncoding -> \"Unsigned\" (default) interprets basis states as natural numbers {0, ..., 2^numQubits-1}.
 BitEncoding -> \"TwosComplement\" interprets basis states as two's complement signed numbers, {0, ... 2^(numQubits-1)-1} and {-1, -2, ... -2^(numQubits-1)}. The last qubit in a sub-register list is assumed the sign bit."
     
@@ -731,7 +737,7 @@ P[outcomes] is a (normalised) projector onto the given {0,1} outcomes. The left 
         	{extractCoeffExpo[s] @ term}
             
         (* for extracting {coeffs}, {exponents} from an n-D exponential-polynomial *)
-        extractMultiExpPolyTerms[terms_List, symbs:{_Symbol ..}] := 
+        extractMultiExpPolyTerms[terms_List, symbs:{__Symbol}] := 
         	Module[{coeffs,powers, cp, badterms},
         		coeffs = Association @@ Table[s->{},{s,symbs}];
         		powers = Association @@ Table[s->{},{s,symbs}];
@@ -755,48 +761,15 @@ P[outcomes] is a (normalised) projector onto the given {0,1} outcomes. The left 
         		If[badterms === {}, 
         			{Values @ coeffs, Values @ powers},
         			badterms]]
-        extractMultiExpPolyTerms[poly_Plus, symbs:{_Symbol ..}] := 
+        extractMultiExpPolyTerms[poly_Plus, symbs:{__Symbol}] := 
             extractMultiExpPolyTerms[List @@ poly, symbs]
-        extractMultiExpPolyTerms[term_, symbs:{_Symbol ..}] := 
+        extractMultiExpPolyTerms[term_, symbs:{__Symbol}] := 
             extractMultiExpPolyTerms[{term}, symbs]
             
         bitEncodingFlags = {  (* these must match the values of the enum bitEncoding in QuEST.h *)
             "Unsigned" -> 0,
             "TwosComplement" -> 1
         };
-        
-        Options[ApplyPhaseFunc] = {
-            BitEncoding -> "Unsigned",
-            PhaseOverrides -> {}
-        };
-            
-        (* 1D exp-poly *)
-        ApplyPhaseFunc[qureg_Integer, qubits:{_Integer..}, phaseFunc_, phaseIndSymb_Symbol, phaseOverrides:{(_Integer -> _?Internal`RealValuedNumericQ) ...}:{}, OptionsPattern[ApplyPhaseFunc]] := 
-            With[
-                {terms = extractExpPolyTerms[N @ phaseFunc,phaseIndSymb]},
-                {badterms = Cases[terms, {$Failed, bad_} :> bad]},
-                If[ Length[badterms] === 0,
-                    ApplyPhaseFuncInternal[qureg, qubits, OptionValue[BitEncoding] /. bitEncodingFlags, terms[[All,1]], terms[[All,2]], phaseOverrides[[All,1]], N @ phaseOverrides[[All,2]]],
-                    (Message[ApplyPhaseFunc::error, "The phase function, which must be an exponential-polynomial, contained an unrecognised term of the form " <> ToString@StandardForm@First@badterms <> "."]; 
-                     $Failed)]]
-        
-        (* n-D errors *)
-        ApplyPhaseFunc[qureg_Integer, regs:{{_Integer..}..}, phaseFunc_, phaseIndSymbs:{_Symbol..}, phaseOverrides:{({_Integer..} -> _?Internal`RealValuedNumericQ) ...}:{}, OptionsPattern[ApplyPhaseFunc]] /; (
-            Not @ DuplicateFreeQ @ phaseIndSymbs || Length @ regs =!= Length @ phaseIndSymbs) :=
-                (Message[ApplyPhaseFunc::error, "Each delimited group of qubits must correspond to a unique symbol in the phase function."];
-                 $Failed)
-        ApplyPhaseFunc[qureg_Integer, regs:{{_Integer..}..}, phaseFunc_, phaseIndSymbs:{_Symbol..}, phaseOverrides:{({_Integer..} -> _?Internal`RealValuedNumericQ) ..}, OptionsPattern[ApplyPhaseFunc]] /; (
-            Not[Equal @@ Length /@ phaseOverrides[[All,1]]] || Length[phaseIndSymbs] =!= Length @ phaseOverrides[[1,1]]) :=
-                (Message[ApplyPhaseFunc::error, "Each overriden phase index must be specified as an n-tuple, where n is the number of qubit groups / symbols."];
-                 $Failed)
-        ApplyPhaseFunc[qureg_Integer, regs:{{_Integer..}..}, phaseFunc_, phaseIndSymbs:{_Symbol..}, phaseOverrides:{(_Integer -> _?Internal`RealValuedNumericQ) ..}, OptionsPattern[ApplyPhaseFunc]] :=
-            (Message[ApplyPhaseFunc::error, "Each overriden phase index must be specified as an n-tuple, where n is the number of qubit groups / symbols."];
-             $Failed)
-        ApplyPhaseFunc[qureg_Integer, regs:{{_Integer..}..}, phaseFunc_, phaseOverrides:{(_Integer -> _?Internal`RealValuedNumericQ) ..}, OptionsPattern[ApplyPhaseFunc]] :=
-            (Message[ApplyPhaseFunc::error, "Each overriden phase index must be specified as an n-tuple, where n is the number of qubit groups / symbols."];
-            $Failed)
-        
-        (* n-D named *)
         phaseFuncFlags = {    (* these must match the values of the enum phaseFunc in QuEST.h *)
             "Norm" -> 0,
             "InverseNorm" -> 1,
@@ -804,34 +777,83 @@ P[outcomes] is a (normalised) projector onto the given {0,1} outcomes. The left 
             "ScaledInverseNorm" -> 3,
             "ScaledProduct" -> 4
         };
-        ApplyPhaseFunc[qureg_Integer, regs:{{_Integer..}..}, (_String|{_String, (_?Internal`RealValuedNumericQ...)}), phaseOverrides:{({_Integer..} -> _?Internal`RealValuedNumericQ) ..}, OptionsPattern[ApplyPhaseFunc]] /; (
-            Not[Equal @@ Length /@ phaseOverrides[[All,1]]] || Length[regs] =!= Length @ phaseOverrides[[1,1]]) :=
-                (Message[ApplyPhaseFunc::error, "Each overriden phase index must be specified as an n-tuple, where n is the number of qubit groups."];
-                 $Failed)
-        ApplyPhaseFunc[qureg_Integer, regs:{{_Integer..}..}, phaseFunc_String, phaseOverrides:{({_Integer..} -> _?Internal`RealValuedNumericQ) ...}:{}, OptionsPattern[ApplyPhaseFunc]] := 
-            If[
-                MemberQ[ phaseFuncFlags[[All,1]], phaseFunc],
-                ApplyNamedPhaseFuncInternal[qureg, Flatten[regs], Length/@regs, OptionValue[BitEncoding] /. bitEncodingFlags, phaseFunc /. phaseFuncFlags, Flatten[phaseOverrides[[All,1]]], N @ phaseOverrides[[All,2]]],
-                (Message[ApplyPhaseFunc::error, "The phase function name must be one of " <> ToString[phaseFuncFlags[[All,1]]]]; 
-                 $Failed)]
-        ApplyPhaseFunc[qureg_Integer, regs:{{_Integer..}..}, {phaseFunc_String, params:(_?Internal`RealValuedNumericQ...)}, phaseOverrides:{({_Integer..} -> _?Internal`RealValuedNumericQ) ...}:{}, OptionsPattern[ApplyPhaseFunc]] := 
-            If[
-                MemberQ[ phaseFuncFlags[[All,1]], phaseFunc],
-                ApplyParamNamedPhaseFuncInternal[qureg, Flatten[regs], Length/@regs, OptionValue[BitEncoding] /. bitEncodingFlags, phaseFunc /. phaseFuncFlags, {params}, Flatten[phaseOverrides[[All,1]]], N @ phaseOverrides[[All,2]]],
-                (Message[ApplyPhaseFunc::error, "The phase function name must be one of " <> ToString[phaseFuncFlags[[All,1]]]]; 
-                 $Failed)]
+        Options[ApplyPhaseFunc] = {
+            BitEncoding -> "Unsigned",
+            PhaseOverrides -> {}
+        };
         
-        (* n-D exp-poly *)
-        ApplyPhaseFunc[qureg_Integer, regs:{{_Integer..}..}, phaseFunc_, phaseIndSymbs:{_Symbol..}, phaseOverrides:{({_Integer..} -> _?Internal`RealValuedNumericQ) ...}:{}, OptionsPattern[ApplyPhaseFunc]] :=
-            With[
-                {terms = extractMultiExpPolyTerms[N @ phaseFunc, phaseIndSymbs]},
-                {badterms = Cases[terms, {$Failed, bad_} :> bad]},
-                {coeffs = First[terms], exponents=Last[terms]},
-                If[ Length[badterms] === 0,
-                    ApplyMultiVarPhaseFuncInternal[qureg, Flatten[regs], Length/@regs, OptionValue[BitEncoding] /. bitEncodingFlags, Flatten[coeffs], Flatten[exponents], Length/@coeffs, Flatten[phaseOverrides[[All,1]]], N @ phaseOverrides[[All,2]]],
+        (* single-variable exponential polynomial func *)
+        ApplyPhaseFunc[qureg_Integer, reg:{__Integer}, func_, symb_Symbol, OptionsPattern[]] := With[
+            {terms = extractExpPolyTerms[N @ func, symb]},
+            {badterms = Cases[terms, {$Failed, bad_} :> bad]},
+            {overs = OptionValue[PhaseOverrides]},
+            Which[
+                Length[badterms] > 0,
                     (Message[ApplyPhaseFunc::error, "The phase function, which must be an exponential-polynomial, contained an unrecognised term of the form " <> ToString@StandardForm@First@badterms <> "."]; 
-                     $Failed)]]
+                    $Failed),
+                Not @ MemberQ[bitEncodingFlags[[All,1]], OptionValue[BitEncoding]],
+                    (Message[ApplyPhaseFunc::error, "Invalid option for BitEncoding. Must be one of " <> ToString@bitEncodingFlags[[All, 1]] <> "."]; 
+                    $Failed),
+                Not @ MatchQ[overs, {(_Integer -> _?Internal`RealValuedNumericQ) ...}],
+                    (Message[ApplyPhaseFunc::error, "Invalid one-dimensional PhaseOverrides, which must be of the form {integer -> real, ...}"]; 
+                    $Failed),
+                True,
+                    ApplyPhaseFuncInternal[qureg, reg, OptionValue[BitEncoding] /. bitEncodingFlags, terms[[All,1]], terms[[All,2]], overs[[All,1]], N @ overs[[All,2]]]]]
+            
+        (* multi-variable exponential polynomial func *)
+        ApplyPhaseFunc[qureg_Integer, regs:{{__Integer}..}, func_, symbs:{__Symbol}, OptionsPattern[]] := With[
+            {terms = extractMultiExpPolyTerms[N @ func, symbs]},
+            {badterms = Cases[terms, {$Failed, bad_} :> bad]},
+            {coeffs = First[terms], exponents=Last[terms]},
+            {overs = OptionValue[PhaseOverrides]},
+            Which[
+                Not @ DuplicateFreeQ @ symbs,
+                    (Message[ApplyPhaseFunc::error, "The list of phase function symbols must be unique."];
+                    $Failed),
+                Length[regs] =!= Length[symbs],
+                    (Message[ApplyPhaseFunc::error, "Each delimited sub-register of qubits must correspond to a unique symbol in the phase function."];
+                    $Failed),
+                Length[badterms] > 0,
+                    (Message[ApplyPhaseFunc::error, "The phase function, which must be an exponential-polynomial, contained an unrecognised term of the form " <> ToString@StandardForm@First@badterms <> "."]; 
+                     $Failed),
+                Not @ MemberQ[bitEncodingFlags[[All,1]], OptionValue[BitEncoding]],
+                    (Message[ApplyPhaseFunc::error, "Invalid option for BitEncoding. Must be one of " <> ToString@bitEncodingFlags[[All, 1]] <> "."]; 
+                    $Failed),
+                Not[ (overs === {}) || And[
+                        MatchQ[overs, {({__Integer} -> _?Internal`RealValuedNumericQ) ..}],
+                        Equal @@ Length /@ overs[[All,1]], 
+                        Length[regs] === Length@overs[[1,1]] ] ],
+                    (Message[ApplyPhaseFunc::error, "Invalid PhaseOverrides. Each overriden phase index must be specified as an n-tuple, where n is the number of sub-registers and symbols, pointing to a real number. For example, ApplyPhaseFunc[..., {x,y}, PhaseOverrides -> { {0,0} -> PI, ... }]."];
+                     $Failed),
+                True,
+                    ApplyMultiVarPhaseFuncInternal[qureg, Flatten[regs], Length/@regs, OptionValue[BitEncoding] /. bitEncodingFlags, Flatten[coeffs], Flatten[exponents], Length/@coeffs, Flatten[overs[[All,1]]], N @ overs[[All,2]]]]]
+
+        (* parameterised named func (multi-variable) *)
+        ApplyPhaseFunc[qureg_Integer, regs:{{__Integer}..}, {func_String, params___?Internal`RealValuedNumericQ}, OptionsPattern[]] := With[
+            {overs = OptionValue[PhaseOverrides]},
+            Which[
+                Not @ MemberQ[phaseFuncFlags[[All,1]], func],
+                    (Message[ApplyPhaseFunc::error, "The named phase function must be one of " <> ToString[phaseFuncFlags[[All,1]]]]; 
+                     $Failed),
+                Not @ MemberQ[bitEncodingFlags[[All,1]], OptionValue[BitEncoding]],
+                    (Message[ApplyPhaseFunc::error, "Invalid option for BitEncoding. Must be one of " <> ToString@bitEncodingFlags[[All, 1]] <> "."]; 
+                    $Failed),
+                Not[ (overs === {}) || And[
+                        MatchQ[overs, {({__Integer} -> _?Internal`RealValuedNumericQ) ..}],
+                        Equal @@ Length /@ overs[[All,1]], 
+                        Length[regs] === Length@overs[[1,1]] ] ],
+                    (Message[ApplyPhaseFunc::error, "Invalid PhaseOverrides. Each overriden phase index must be specified as an n-tuple, where n is the number of sub-registers, pointing to a real number. For example, ApplyPhaseFunc[..., {{1},{2}}, ..., PhaseOverrides -> { {0,0} -> PI, ... }]."];
+                     $Failed),
+                Length[{params}] === 0,
+                    ApplyNamedPhaseFuncInternal[qureg, Flatten[regs], Length/@regs, OptionValue[BitEncoding] /. bitEncodingFlags, func /. phaseFuncFlags, Flatten[overs[[All,1]]], N @ overs[[All,2]]],
+                Length[{params}] > 0,
+                    ApplyParamNamedPhaseFuncInternal[qureg, Flatten[regs], Length/@regs, OptionValue[BitEncoding] /. bitEncodingFlags, func /. phaseFuncFlags, N @ {params}, Flatten[overs[[All,1]]], N @ overs[[All,2]]]]]
         
+        (* non-parameterised named func (multi-variable) *)
+        ApplyPhaseFunc[qureg_Integer, regs:{{__Integer}..}, func_String, opts:OptionsPattern[]] := 
+            ApplyPhaseFunc[qureg, regs, {func}, opts]
+        
+        (* invalid args and symbol syntax highlighting *)
         ApplyPhaseFunc[___] := invalidArgError[ApplyPhaseFunc]
         SyntaxInformation[ApplyPhaseFunc] = {"LocalVariables" -> {"Solve", {4, 4}}};
         

--- a/Link/quest_link.cpp
+++ b/Link/quest_link.cpp
@@ -2076,7 +2076,7 @@ void internal_applyPauliSum(int inId, int outId) {
     }
 }
 
-void internal_applyPhaseFunc(int quregId, int* qubits, long numQubits) {
+void internal_applyPhaseFunc(int quregId, int* qubits, long numQubits, int encoding) {
     
     // fetch args into dynamic memory
     qreal* coeffs;
@@ -2100,7 +2100,8 @@ void internal_applyPhaseFunc(int quregId, int* qubits, long numQubits) {
         local_throwExcepIfQuregNotCreated(quregId); // throws
         Qureg qureg = quregs[quregId];
         
-        applyPhaseFuncOverrides(qureg, qubits, numQubits, coeffs, exponents, numTerms, overrideInds, overridePhases, numOverrides); // throws
+        applyPhaseFuncOverrides(qureg, qubits, numQubits, (enum bitEncoding) encoding, coeffs, exponents, numTerms, overrideInds, overridePhases, numOverrides); // throws
+        
         WSPutInteger(stdlink, quregId);
         
     } catch (QuESTException& err) {
@@ -2122,6 +2123,7 @@ void internal_applyMultiVarPhaseFunc(int quregId) {
     int* qubits;
     int* numQubitsPerReg;
     int numRegs;
+    int encoding;
     qreal* coeffs;
     qreal* exponents;
     int* numTermsPerReg;
@@ -2134,6 +2136,7 @@ void internal_applyMultiVarPhaseFunc(int quregId) {
     int dummy_totalInds;
     WSGetInteger32List(stdlink, &qubits, &dummy_totalQubits);
     WSGetInteger32List(stdlink, &numQubitsPerReg, &numRegs);
+    WSGetInteger32(stdlink, &encoding);
     WSGetReal64List(stdlink, &coeffs, &dummy_totalTerms);
     WSGetReal64List(stdlink, &exponents, &dummy_totalTerms);
     WSGetInteger32List(stdlink, &numTermsPerReg, &numRegs);
@@ -2149,7 +2152,7 @@ void internal_applyMultiVarPhaseFunc(int quregId) {
         local_throwExcepIfQuregNotCreated(quregId); // throws
         Qureg qureg = quregs[quregId];
         
-        applyMultiVarPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, coeffs, exponents, numTermsPerReg, overrideInds, overridePhases, numOverrides);
+        applyMultiVarPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, (enum bitEncoding) encoding, coeffs, exponents, numTermsPerReg, overrideInds, overridePhases, numOverrides);
         
         WSPutInteger(stdlink, quregId);
         
@@ -2177,6 +2180,7 @@ void internal_applyNamedPhaseFunc(int quregId) {
     int* qubits;
     int* numQubitsPerReg;
     int numRegs;
+    int encoding;
     int funcNameCode;
     wsint64* ws_overrideInds;
     qreal* overridePhases;
@@ -2185,6 +2189,7 @@ void internal_applyNamedPhaseFunc(int quregId) {
     int dummy_totalInds; // (irrelevant flattened list lengths)
     WSGetInteger32List(stdlink, &qubits, &dummy_totalQubits);
     WSGetInteger32List(stdlink, &numQubitsPerReg, &numRegs);
+    WSGetInteger32(stdlink, &encoding);
     WSGetInteger32(stdlink, &funcNameCode);
     WSGetInteger64List(stdlink, &ws_overrideInds, &dummy_totalInds);
     WSGetReal64List(stdlink, &overridePhases, &numOverrides);
@@ -2198,7 +2203,7 @@ void internal_applyNamedPhaseFunc(int quregId) {
         local_throwExcepIfQuregNotCreated(quregId); // throws
         Qureg qureg = quregs[quregId];
         
-        applyNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, (enum phaseFunc) funcNameCode, overrideInds, overridePhases, numOverrides);
+        applyNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, (enum bitEncoding) encoding, (enum phaseFunc) funcNameCode, overrideInds, overridePhases, numOverrides);
         
         WSPutInteger(stdlink, quregId);
         
@@ -2224,6 +2229,7 @@ void internal_applyParamNamedPhaseFunc(int quregId) {
     int* qubits;
     int* numQubitsPerReg;
     int numRegs;
+    int encoding;
     int funcNameCode;
     qreal* params;
     int numParams;
@@ -2234,6 +2240,7 @@ void internal_applyParamNamedPhaseFunc(int quregId) {
     int dummy_totalInds; // (irrelevant flattened list lengths)
     WSGetInteger32List(stdlink, &qubits, &dummy_totalQubits);
     WSGetInteger32List(stdlink, &numQubitsPerReg, &numRegs);
+    WSGetInteger32(stdlink, &encoding);
     WSGetInteger32(stdlink, &funcNameCode);
     WSGetReal64List(stdlink, &params, &numParams);
     WSGetInteger64List(stdlink, &ws_overrideInds, &dummy_totalInds);
@@ -2248,7 +2255,7 @@ void internal_applyParamNamedPhaseFunc(int quregId) {
         local_throwExcepIfQuregNotCreated(quregId); // throws
         Qureg qureg = quregs[quregId];
         
-        applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, (enum phaseFunc) funcNameCode, params, numParams, overrideInds, overridePhases, numOverrides);
+        applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, (enum bitEncoding) encoding, (enum phaseFunc) funcNameCode, params, numParams, overrideInds, overridePhases, numOverrides);
         
         WSPutInteger(stdlink, quregId);
         

--- a/Link/quest_templates.tm
+++ b/Link/quest_templates.tm
@@ -206,43 +206,43 @@
 
 :Begin:
 :Function:       internal_applyPhaseFunc
-:Pattern:        QuEST`Private`ApplyPhaseFuncInternal[quregId_Integer, qubits_List, coeffs_List, exponents_List, overrideInds_List, overridePhases_List]
-:Arguments:      { quregId, qubits, coeffs, exponents, overrideInds, overridePhases }
-:ArgumentTypes:  { Integer, IntegerList, Manual }
+:Pattern:        QuEST`Private`ApplyPhaseFuncInternal[quregId_Integer, qubits_List, encoding_Integer, coeffs_List, exponents_List, overrideInds_List, overridePhases_List]
+:Arguments:      { quregId, qubits, encoding, coeffs, exponents, overrideInds, overridePhases }
+:ArgumentTypes:  { Integer, IntegerList, Integer, Manual }
 :ReturnType:     Manual
 :End:
 :Evaluate: 
-    QuEST`Private`ApplyPhaseFuncInternal::usage = "ApplyPhaseFuncInternal[quregId, qubits, coeffs, exponents, overrideInds, overridePhases] applies a diagonal unitary operator upon the qureg, with elements informed by the exponential-polynomial encoded in {coeffs}, {exponents}, applied to the state index informed by {qubits}.";
+    QuEST`Private`ApplyPhaseFuncInternal::usage = "ApplyPhaseFuncInternal[quregId, qubits, encoding, coeffs, exponents, overrideInds, overridePhases] applies a diagonal unitary operator upon the qureg, with elements informed by the exponential-polynomial encoded in {coeffs}, {exponents}, applied to the state index informed by {qubits}.";
 
 :Begin:
 :Function:       internal_applyMultiVarPhaseFunc
-:Pattern:        QuEST`Private`ApplyMultiVarPhaseFuncInternal[quregId_Integer, qubits_List, numQubitsPerReg_List, coeffs_List, exponents_List, numTermsPerReg_List, overrideInds_List, overridePhases_List]
-:Arguments:      { quregId, qubits, numQubitsPerReg, coeffs, exponents, numTermsPerReg, overrideInds, overridePhases }
+:Pattern:        QuEST`Private`ApplyMultiVarPhaseFuncInternal[quregId_Integer, qubits_List, numQubitsPerReg_List, encoding_Integer, coeffs_List, exponents_List, numTermsPerReg_List, overrideInds_List, overridePhases_List]
+:Arguments:      { quregId, qubits, numQubitsPerReg, encoding, coeffs, exponents, numTermsPerReg, overrideInds, overridePhases }
 :ArgumentTypes:  { Integer, Manual }
 :ReturnType:     Manual
 :End:
 :Evaluate: 
-    QuEST`Private`ApplyMultiVarPhaseFuncInternal::usage = "ApplyMultiVarPhaseFuncInternal[quregId, qubits, numQubitsPerReg, coeffs, exponents, numTermsPerReg, overrideInds, overridePhases] applies a diagonal unitary operator upon the qureg, with elements informed by the multi-variable exponential-polynomial encoded in {coeffs}, {exponents}, applied to the state indices informed by {qubits}.";
+    QuEST`Private`ApplyMultiVarPhaseFuncInternal::usage = "ApplyMultiVarPhaseFuncInternal[quregId, qubits, numQubitsPerReg, encoding, coeffs, exponents, numTermsPerReg, overrideInds, overridePhases] applies a diagonal unitary operator upon the qureg, with elements informed by the multi-variable exponential-polynomial encoded in {coeffs}, {exponents}, applied to the state indices informed by {qubits}.";
 
 :Begin:
 :Function:       internal_applyNamedPhaseFunc
-:Pattern:        QuEST`Private`ApplyNamedPhaseFuncInternal[quregId_Integer, qubits_List, numQubitsPerReg_List, phaseFuncName_Integer, overrideInds_List, overridePhases_List]
-:Arguments:      { quregId, qubits, numQubitsPerReg, phaseFuncName, overrideInds, overridePhases }
+:Pattern:        QuEST`Private`ApplyNamedPhaseFuncInternal[quregId_Integer, qubits_List, numQubitsPerReg_List, encoding_Integer, phaseFuncName_Integer, overrideInds_List, overridePhases_List]
+:Arguments:      { quregId, qubits, numQubitsPerReg, encoding, phaseFuncName, overrideInds, overridePhases }
 :ArgumentTypes:  { Integer, Manual }
 :ReturnType:     Manual
 :End:
 :Evaluate: 
-    QuEST`Private`ApplyNamedPhaseFuncInternal::usage = "ApplyNamedPhaseFuncInternal[quregId, qubits, numQubitsPerReg, phaseFuncName, overrideInds, overridePhases] applies a diagonal unitary operator upon the qureg, with elements informed by the multi-variable function implied by phaseFuncName, applied to the state indices informed by {qubits}.";
+    QuEST`Private`ApplyNamedPhaseFuncInternal::usage = "ApplyNamedPhaseFuncInternal[quregId, qubits, numQubitsPerReg, encoding, phaseFuncName, overrideInds, overridePhases] applies a diagonal unitary operator upon the qureg, with elements informed by the multi-variable function implied by phaseFuncName, applied to the state indices informed by {qubits}.";
 
 :Begin:
 :Function:       internal_applyParamNamedPhaseFunc
-:Pattern:        QuEST`Private`ApplyParamNamedPhaseFuncInternal[quregId_Integer, qubits_List, numQubitsPerReg_List, phaseFuncName_Integer, params_List, overrideInds_List, overridePhases_List]
-:Arguments:      { quregId, qubits, numQubitsPerReg, phaseFuncName, params, overrideInds, overridePhases }
+:Pattern:        QuEST`Private`ApplyParamNamedPhaseFuncInternal[quregId_Integer, qubits_List, numQubitsPerReg_List, encoding_Integer, phaseFuncName_Integer, params_List, overrideInds_List, overridePhases_List]
+:Arguments:      { quregId, qubits, numQubitsPerReg, encoding, phaseFuncName, params, overrideInds, overridePhases }
 :ArgumentTypes:  { Integer, Manual }
 :ReturnType:     Manual
 :End:
 :Evaluate: 
-    QuEST`Private`ApplyParamNamedPhaseFuncInternal::usage = "ApplyParamNamedPhaseFuncInternal[quregId, qubits, numQubitsPerReg, phaseFuncName, params, overrideInds, overridePhases] applies a diagonal unitary operator upon the qureg, with elements informed by the multi-variable function implied by phaseFuncName, applied to the state indices informed by {qubits}.";
+    QuEST`Private`ApplyParamNamedPhaseFuncInternal::usage = "ApplyParamNamedPhaseFuncInternal[quregId, qubits, numQubitsPerReg, encoding, phaseFuncName, params, overrideInds, overridePhases] applies a diagonal unitary operator upon the qureg, with elements informed by the multi-variable function implied by phaseFuncName, applied to the state indices informed by {qubits}.";
 
 
 :Begin:

--- a/Link/quest_templates.tm
+++ b/Link/quest_templates.tm
@@ -234,6 +234,16 @@
 :Evaluate: 
     QuEST`Private`ApplyNamedPhaseFuncInternal::usage = "ApplyNamedPhaseFuncInternal[quregId, qubits, numQubitsPerReg, phaseFuncName, overrideInds, overridePhases] applies a diagonal unitary operator upon the qureg, with elements informed by the multi-variable function implied by phaseFuncName, applied to the state indices informed by {qubits}.";
 
+:Begin:
+:Function:       internal_applyParamNamedPhaseFunc
+:Pattern:        QuEST`Private`ApplyParamNamedPhaseFuncInternal[quregId_Integer, qubits_List, numQubitsPerReg_List, phaseFuncName_Integer, params_List, overrideInds_List, overridePhases_List]
+:Arguments:      { quregId, qubits, numQubitsPerReg, phaseFuncName, params, overrideInds, overridePhases }
+:ArgumentTypes:  { Integer, Manual }
+:ReturnType:     Manual
+:End:
+:Evaluate: 
+    QuEST`Private`ApplyParamNamedPhaseFuncInternal::usage = "ApplyParamNamedPhaseFuncInternal[quregId, qubits, numQubitsPerReg, phaseFuncName, params, overrideInds, overridePhases] applies a diagonal unitary operator upon the qureg, with elements informed by the multi-variable function implied by phaseFuncName, applied to the state indices informed by {qubits}.";
+
 
 :Begin:
 :Function:       wrapper_mixDepolarising

--- a/QuEST/include/QuEST.h
+++ b/QuEST/include/QuEST.h
@@ -217,14 +217,15 @@ void applyTwoQubitMatrix(Qureg qureg, int targetQubit1, int targetQubit2, Comple
 
 // added prematurely since urgent & QuEST backend isn't ready to pull to QuESTlink
 enum phaseFunc {NORM=0, INVERSE_NORM=1, SCALED_NORM=2, SCALED_INVERSE_NORM=3, SCALED_PRODUCT=4};
-void applyPhaseFunc(Qureg qureg, int* qubits, int numQubits, qreal* coeffs, qreal* exponents, int numTerms);
-void applyPhaseFuncOverrides(Qureg qureg, int* qubits, int numQubits, qreal* coeffs, qreal* exponents, int numTerms, long long int* overrideInds, qreal* overridePhases, int numOverrides);
-void applyMultiVarPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, qreal* coeffs, qreal* exponents, int* numTermsPerReg);
-void applyMultiVarPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, qreal* coeffs, qreal* exponents, int* numTermsPerReg, long long int* overrideInds, qreal* overridePhases, int numOverrides);
-void applyNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum phaseFunc functionNameCode);
-void applyNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum phaseFunc functionNameCode, long long int* overrideInds, qreal* overridePhases, int numOverrides);
-void applyParamNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum phaseFunc functionNameCode, qreal* params, int numParams);
-void applyParamNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum phaseFunc functionNameCode, qreal* params, int numParams, long long int* overrideInds, qreal* overridePhases, int numOverrides);
+enum bitEncoding {UNSIGNED=0, TWOS_COMPLEMENT=1};
+void applyPhaseFunc(Qureg qureg, int* qubits, int numQubits, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int numTerms);
+void applyPhaseFuncOverrides(Qureg qureg, int* qubits, int numQubits, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int numTerms, long long int* overrideInds, qreal* overridePhases, int numOverrides);
+void applyMultiVarPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int* numTermsPerReg);
+void applyMultiVarPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int* numTermsPerReg, long long int* overrideInds, qreal* overridePhases, int numOverrides);
+void applyNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, enum phaseFunc functionNameCode);
+void applyNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, enum phaseFunc functionNameCode, long long int* overrideInds, qreal* overridePhases, int numOverrides);
+void applyParamNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, enum phaseFunc functionNameCode, qreal* params, int numParams);
+void applyParamNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, enum phaseFunc functionNameCode, qreal* params, int numParams, long long int* overrideInds, qreal* overridePhases, int numOverrides);
 
 /*
  * public functions

--- a/QuEST/include/QuEST.h
+++ b/QuEST/include/QuEST.h
@@ -216,7 +216,7 @@ void applyOneQubitMatrix(Qureg qureg, int targetQubit,  ComplexMatrix2 u);
 void applyTwoQubitMatrix(Qureg qureg, int targetQubit1, int targetQubit2, ComplexMatrix4 u);
 
 // added prematurely since urgent & QuEST backend isn't ready to pull to QuESTlink
-enum phaseFunc {NORM=0, INVERSE_NORM=1, SCALED_NORM=2, SCALED_INVERSE_NORM=3};
+enum phaseFunc {NORM=0, INVERSE_NORM=1, SCALED_NORM=2, SCALED_INVERSE_NORM=3, SCALED_PRODUCT=4};
 void applyPhaseFunc(Qureg qureg, int* qubits, int numQubits, qreal* coeffs, qreal* exponents, int numTerms);
 void applyPhaseFuncOverrides(Qureg qureg, int* qubits, int numQubits, qreal* coeffs, qreal* exponents, int numTerms, long long int* overrideInds, qreal* overridePhases, int numOverrides);
 void applyMultiVarPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, qreal* coeffs, qreal* exponents, int* numTermsPerReg);

--- a/QuEST/include/QuEST.h
+++ b/QuEST/include/QuEST.h
@@ -216,14 +216,15 @@ void applyOneQubitMatrix(Qureg qureg, int targetQubit,  ComplexMatrix2 u);
 void applyTwoQubitMatrix(Qureg qureg, int targetQubit1, int targetQubit2, ComplexMatrix4 u);
 
 // added prematurely since urgent & QuEST backend isn't ready to pull to QuESTlink
-enum phaseFunc {NORM=0, INVERSE_NORM=1};
+enum phaseFunc {NORM=0, INVERSE_NORM=1, SCALED_NORM=2, SCALED_INVERSE_NORM=3};
 void applyPhaseFunc(Qureg qureg, int* qubits, int numQubits, qreal* coeffs, qreal* exponents, int numTerms);
 void applyPhaseFuncOverrides(Qureg qureg, int* qubits, int numQubits, qreal* coeffs, qreal* exponents, int numTerms, long long int* overrideInds, qreal* overridePhases, int numOverrides);
 void applyMultiVarPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, qreal* coeffs, qreal* exponents, int* numTermsPerReg);
 void applyMultiVarPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, qreal* coeffs, qreal* exponents, int* numTermsPerReg, long long int* overrideInds, qreal* overridePhases, int numOverrides);
 void applyNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum phaseFunc functionNameCode);
 void applyNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum phaseFunc functionNameCode, long long int* overrideInds, qreal* overridePhases, int numOverrides);
-
+void applyParamNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum phaseFunc functionNameCode, qreal* params, int numParams);
+void applyParamNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum phaseFunc functionNameCode, qreal* params, int numParams, long long int* overrideInds, qreal* overridePhases, int numOverrides);
 
 /*
  * public functions

--- a/QuEST/src/CPU/QuEST_cpu.c
+++ b/QuEST/src/CPU/QuEST_cpu.c
@@ -254,9 +254,10 @@ void statevec_applyParamNamedPhaseFuncOverrides(
             if (i < numOverrides)
                 phase = overridePhases[i];
             else {
-                // commented out for optimisation, since no other functions exist presently
-                // if (phaseFuncName == NORM || phaseFuncName == INVERSE_NORM ||
-                //    phaseFuncName == SCALED_NORM || phaseFuncName == SCALED_INVERSE_NORM) {
+                // compute norm-related phases
+                if (phaseFuncName == NORM || phaseFuncName == INVERSE_NORM ||
+                    phaseFuncName == SCALED_NORM || phaseFuncName == SCALED_INVERSE_NORM) {
+                        
                     norm = 0;
                     for (r=0; r<numRegs; r++)
                         norm += phaseInds[r]*phaseInds[r];
@@ -270,7 +271,13 @@ void statevec_applyParamNamedPhaseFuncOverrides(
                         phase = params[0] * norm;
                     else if (phaseFuncName == SCALED_INVERSE_NORM)
                         phase = params[0] / norm;
-                //}
+                }
+                // compute algebraic phases
+                else if (phaseFuncName == SCALED_PRODUCT) {
+                    phase = params[0];
+                    for (r=0; r<numRegs; r++)
+                        phase *= phaseInds[r];
+                }
             }
             
             // modify amp to amp * exp(i phase) 

--- a/QuEST/src/CPU/QuEST_cpu.c
+++ b/QuEST/src/CPU/QuEST_cpu.c
@@ -40,7 +40,7 @@
  */
  
 void statevec_applyPhaseFuncOverrides(
-    Qureg qureg, int* qubits, int numQubits, 
+    Qureg qureg, int* qubits, int numQubits, enum bitEncoding encoding,
     qreal* coeffs, qreal* exponents, int numTerms, 
     long long int* overrideInds, qreal* overridePhases, int numOverrides)
 {
@@ -60,7 +60,7 @@ void statevec_applyPhaseFuncOverrides(
 # ifdef _OPENMP
 # pragma omp parallel \
     default  (none) \
-    shared   (chunkId,numAmps, stateRe,stateIm, qubits,numQubits, coeffs,exponents,numTerms, overrideInds,overridePhases,numOverrides) \
+    shared   (chunkId,numAmps, stateRe,stateIm, qubits,numQubits,encoding, coeffs,exponents,numTerms, overrideInds,overridePhases,numOverrides) \
     private  (index, globalAmpInd, phaseInd, i,t,q, phase, c,s,re,im) 
 # endif
     {
@@ -74,8 +74,16 @@ void statevec_applyPhaseFuncOverrides(
             
             // determine phase index of {qubits}
             phaseInd = 0LL;
-            for (q=0; q<numQubits; q++)
-                phaseInd += (1LL << q) * extractBit(qubits[q], globalAmpInd);
+            if (encoding == UNSIGNED) {
+                for (q=0; q<numQubits; q++) // use significance order specified by {qubits}
+                    phaseInd += (1LL << q) * extractBit(qubits[q], globalAmpInd);
+            } 
+            else if (encoding == TWOS_COMPLEMENT) {
+                for (q=0; q<numQubits-1; q++) // use final qubit to indicate sign 
+                    phaseInd += (1LL << q) * extractBit(qubits[q], globalAmpInd);
+                if (extractBit(qubits[numQubits-1], globalAmpInd) == 1)
+                    phaseInd -= (1LL << (numQubits-1));
+            }
             
             // determine if this phase index has an overriden value (i < numOverrides)
             for (i=0; i<numOverrides; i++)
@@ -104,7 +112,7 @@ void statevec_applyPhaseFuncOverrides(
 }
 
 void statevec_applyMultiVarPhaseFuncOverrides(
-    Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, 
+    Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding,
     qreal* coeffs, qreal* exponents, int* numTermsPerReg, 
     long long int* overrideInds, qreal* overridePhases, int numOverrides) 
 {
@@ -129,7 +137,7 @@ void statevec_applyMultiVarPhaseFuncOverrides(
 # ifdef _OPENMP
 # pragma omp parallel \
     default  (none) \
-    shared   (chunkId,numAmps, stateRe,stateIm, qubits,numQubitsPerReg,numRegs, coeffs,exponents,numTermsPerReg, overrideInds,overridePhases,numOverrides) \
+    shared   (chunkId,numAmps, stateRe,stateIm, qubits,numQubitsPerReg,numRegs,encoding, coeffs,exponents,numTermsPerReg, overrideInds,overridePhases,numOverrides) \
     private  (index,globalAmpInd, r,q,i,t,flatInd, found, phaseInds,phase, c,s,re,im) 
 # endif
     {
@@ -145,8 +153,18 @@ void statevec_applyMultiVarPhaseFuncOverrides(
             flatInd = 0;
             for (r=0; r<numRegs; r++) {
                 phaseInds[r] = 0LL;
-                for (q=0; q<numQubitsPerReg[r]; q++)
-                    phaseInds[r] += (1LL << q) * extractBit(qubits[flatInd++], globalAmpInd);   // qubits[flatInd] ~ qubits[r][q]
+                
+                if (encoding == UNSIGNED) {
+                    for (q=0; q<numQubitsPerReg[r]; q++)
+                        phaseInds[r] += (1LL << q) * extractBit(qubits[flatInd++], globalAmpInd);   // qubits[flatInd] ~ qubits[r][q]
+                }
+                else if (encoding == TWOS_COMPLEMENT) {
+                    for (q=0; q<numQubitsPerReg[r]-1; q++)  
+                        phaseInds[r] += (1LL << q) * extractBit(qubits[flatInd++], globalAmpInd);
+                    // use final qubit to indicate sign
+                    if (extractBit(qubits[flatInd++], globalAmpInd) == 1)
+                        phaseInds[r] -= (1LL << (numQubitsPerReg[r]-1));
+                }
             }
             
             // determine if this phase index has an overriden value (i < numOverrides)
@@ -190,7 +208,7 @@ void statevec_applyMultiVarPhaseFuncOverrides(
 }
 
 void statevec_applyParamNamedPhaseFuncOverrides(
-    Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, 
+    Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding,
     enum phaseFunc phaseFuncName,
     qreal* params, int numParams,
     long long int* overrideInds, qreal* overridePhases, int numOverrides) 
@@ -216,7 +234,7 @@ void statevec_applyParamNamedPhaseFuncOverrides(
 # ifdef _OPENMP
 # pragma omp parallel \
     default  (none) \
-    shared   (chunkId,numAmps, stateRe,stateIm, qubits,numQubitsPerReg,numRegs, phaseFuncName,params,numParams, overrideInds,overridePhases,numOverrides) \
+    shared   (chunkId,numAmps, stateRe,stateIm, qubits,numQubitsPerReg,numRegs,encoding, phaseFuncName,params,numParams, overrideInds,overridePhases,numOverrides) \
     private  (index,globalAmpInd, r,q,i,flatInd, found, phaseInds,phase,norm, c,s,re,im) 
 # endif
     {
@@ -232,8 +250,18 @@ void statevec_applyParamNamedPhaseFuncOverrides(
             flatInd = 0;
             for (r=0; r<numRegs; r++) {
                 phaseInds[r] = 0LL;
-                for (q=0; q<numQubitsPerReg[r]; q++)
-                    phaseInds[r] += (1LL << q) * extractBit(qubits[flatInd++], globalAmpInd);   // qubits[flatInd] ~ qubits[r][q]
+                
+                if (encoding == UNSIGNED) {
+                    for (q=0; q<numQubitsPerReg[r]; q++)
+                        phaseInds[r] += (1LL << q) * extractBit(qubits[flatInd++], globalAmpInd);   // qubits[flatInd] ~ qubits[r][q]
+                }
+                else if (encoding == TWOS_COMPLEMENT) {
+                    for (q=0; q<numQubitsPerReg[r]-1; q++)  
+                        phaseInds[r] += (1LL << q) * extractBit(qubits[flatInd++], globalAmpInd);
+                    // use final qubit to indicate sign
+                    if (extractBit(qubits[flatInd++], globalAmpInd) == 1)
+                        phaseInds[r] -= (1LL << (numQubitsPerReg[r]-1));
+                }
             }
             
             // determine if this phase index has an overriden value (i < numOverrides)

--- a/QuEST/src/GPU/QuEST_gpu.cu
+++ b/QuEST/src/GPU/QuEST_gpu.cu
@@ -404,9 +404,9 @@ __global__ void statevec_applyParamNamedPhaseFuncOverridesKernel(
     if (i < numOverrides)
         phase = overridePhases[i];
     else {
-        // commented out for optimisation, since no other functions exist presently
-        // if (phaseFuncName == NORM || phaseFuncName == INVERSE_NORM ||
-        // phaseFuncName == SCALED_NORM || phaseFuncName == SCALED_INVERSE_NORM) {
+        // norm-based phases
+        if (phaseFuncName == NORM || phaseFuncName == INVERSE_NORM ||
+            phaseFuncName == SCALED_NORM || phaseFuncName == SCALED_INVERSE_NORM) {
             qreal norm = 0;
             for (int r=0; r<numRegs; r++)
                 norm += phaseInds[r*stride+offset]*phaseInds[r*stride+offset];
@@ -420,7 +420,13 @@ __global__ void statevec_applyParamNamedPhaseFuncOverridesKernel(
                 phase = params[0] * norm;
             else if (phaseFuncName == SCALED_INVERSE_NORM)
                 phase = params[0] / norm;
-        //}
+        }
+        // algebraic phases
+        else if (phaseFuncName == SCALED_PRODUCT) {
+            phase = params[0];
+            for (int r=0; r<numRegs; r++)
+                phase *= phaseInds[r];
+        }
     }
     
     // modify amp to amp * exp(i phase) 

--- a/QuEST/src/QuEST.c
+++ b/QuEST/src/QuEST.c
@@ -58,88 +58,97 @@ void applyTwoQubitMatrix(Qureg qureg, int targetQubit1, int targetQubit2, Comple
     qasm_recordComment(qureg, "Here, an undisclosed 2-qubit matrix was pre-multiplied.");
 }
 
-void applyPhaseFunc(Qureg qureg, int* qubits, int numQubits, qreal* coeffs, qreal* exponents, int numTerms) {
+void applyPhaseFunc(Qureg qureg, int* qubits, int numQubits, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int numTerms) {
     validateStateVecQureg(qureg, __func__);
     validateMultiQubits(qureg, qubits, numQubits, __func__);
     validateNumPhaseFuncTerms(numTerms, __func__);
+    validateBitEncoding(numQubits, encoding, __func__);
     
-    statevec_applyPhaseFuncOverrides(qureg, qubits, numQubits, coeffs, exponents, numTerms, NULL, NULL, 0);
+    statevec_applyPhaseFuncOverrides(qureg, qubits, numQubits, encoding, coeffs, exponents, numTerms, NULL, NULL, 0);
     
-    qasm_recordPhaseFunc(qureg, qubits, numQubits,coeffs, exponents, numTerms, NULL, NULL, 0);
+    qasm_recordPhaseFunc(qureg, qubits, numQubits, encoding, coeffs, exponents, numTerms, NULL, NULL, 0);
 }
 
-void applyPhaseFuncOverrides(Qureg qureg, int* qubits, int numQubits, qreal* coeffs, qreal* exponents, int numTerms, long long int* overrideInds, qreal* overridePhases, int numOverrides) {
+void applyPhaseFuncOverrides(Qureg qureg, int* qubits, int numQubits, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int numTerms, long long int* overrideInds, qreal* overridePhases, int numOverrides) {
     validateStateVecQureg(qureg, __func__);
     validateMultiQubits(qureg, qubits, numQubits, __func__);
+    validateBitEncoding(numQubits, encoding, __func__);
     validateNumPhaseFuncTerms(numTerms, __func__);
-    validatePhaseFuncOverrides(numQubits, overrideInds, numOverrides, __func__);
+    validatePhaseFuncOverrides(numQubits, encoding, overrideInds, numOverrides, __func__);
     
-    statevec_applyPhaseFuncOverrides(qureg, qubits, numQubits, coeffs, exponents, numTerms, overrideInds, overridePhases, numOverrides);
+    statevec_applyPhaseFuncOverrides(qureg, qubits, numQubits, encoding, coeffs, exponents, numTerms, overrideInds, overridePhases, numOverrides);
     
-    qasm_recordPhaseFunc(qureg, qubits, numQubits,coeffs, exponents, numTerms, overrideInds, overridePhases, numOverrides);
+    qasm_recordPhaseFunc(qureg, qubits, numQubits, encoding, coeffs, exponents, numTerms, overrideInds, overridePhases, numOverrides);
 }
 
-void applyMultiVarPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, qreal* coeffs, qreal* exponents, int* numTermsPerReg) {
+void applyMultiVarPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int* numTermsPerReg) {
     validateStateVecQureg(qureg, __func__);
     validateQubitSubregs(qureg, qubits, numQubitsPerReg, numRegs, __func__);
+    validateMultiRegBitEncoding(numQubitsPerReg, numRegs, encoding, __func__);
+    
     validateNumMultiVarPhaseFuncTerms(numTermsPerReg, numRegs, __func__);
 
-    statevec_applyMultiVarPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, coeffs, exponents, numTermsPerReg, NULL, NULL, 0);
+    statevec_applyMultiVarPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, coeffs, exponents, numTermsPerReg, NULL, NULL, 0);
     
-    qasm_recordMultiVarPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, coeffs, exponents, numTermsPerReg, NULL, NULL, 0);
+    qasm_recordMultiVarPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, encoding, coeffs, exponents, numTermsPerReg, NULL, NULL, 0);
 }
 
-void applyMultiVarPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, qreal* coeffs, qreal* exponents, int* numTermsPerReg, long long int* overrideInds, qreal* overridePhases, int numOverrides) {
+void applyMultiVarPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int* numTermsPerReg, long long int* overrideInds, qreal* overridePhases, int numOverrides) {
     validateStateVecQureg(qureg, __func__);
     validateQubitSubregs(qureg, qubits, numQubitsPerReg, numRegs, __func__);
+    validateMultiRegBitEncoding(numQubitsPerReg, numRegs, encoding, __func__);
     validateNumMultiVarPhaseFuncTerms(numTermsPerReg, numRegs, __func__);
-    validateMultiVarPhaseFuncOverrides(numQubitsPerReg, numRegs, overrideInds, numOverrides, __func__);
+    validateMultiVarPhaseFuncOverrides(numQubitsPerReg, numRegs, encoding, overrideInds, numOverrides, __func__);
 
-    statevec_applyMultiVarPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, coeffs, exponents, numTermsPerReg, overrideInds, overridePhases, numOverrides);
+    statevec_applyMultiVarPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, coeffs, exponents, numTermsPerReg, overrideInds, overridePhases, numOverrides);
     
-    qasm_recordMultiVarPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, coeffs, exponents, numTermsPerReg, overrideInds, overridePhases, numOverrides);
+    qasm_recordMultiVarPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, encoding, coeffs, exponents, numTermsPerReg, overrideInds, overridePhases, numOverrides);
 }
 
-void applyNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum phaseFunc functionNameCode) {
+void applyNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, enum phaseFunc functionNameCode) {
     validateStateVecQureg(qureg, __func__);
     validateQubitSubregs(qureg, qubits, numQubitsPerReg, numRegs, __func__);
+    validateMultiRegBitEncoding(numQubitsPerReg, numRegs, encoding, __func__);
     validatePhaseFuncName(functionNameCode, 0, __func__);
 
-    statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, functionNameCode, NULL, 0, NULL, NULL, 0);
+    statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, NULL, 0, NULL, NULL, 0);
     
-    qasm_recordNamedPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, functionNameCode, NULL, 0, NULL, NULL, 0);
+    qasm_recordNamedPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, NULL, 0, NULL, NULL, 0);
 }
 
-void applyNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum phaseFunc functionNameCode, long long int* overrideInds, qreal* overridePhases, int numOverrides) {
+void applyNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, enum phaseFunc functionNameCode, long long int* overrideInds, qreal* overridePhases, int numOverrides) {
     validateStateVecQureg(qureg, __func__);
     validateQubitSubregs(qureg, qubits, numQubitsPerReg, numRegs, __func__);
+    validateMultiRegBitEncoding(numQubitsPerReg, numRegs, encoding, __func__);
     validatePhaseFuncName(functionNameCode, 0, __func__);
-    validateMultiVarPhaseFuncOverrides(numQubitsPerReg, numRegs, overrideInds, numOverrides, __func__);
+    validateMultiVarPhaseFuncOverrides(numQubitsPerReg, numRegs, encoding, overrideInds, numOverrides, __func__);
 
-    statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, functionNameCode, NULL, 0, overrideInds, overridePhases, numOverrides);
+    statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, NULL, 0, overrideInds, overridePhases, numOverrides);
     
-    qasm_recordNamedPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, functionNameCode, NULL, 0, overrideInds, overridePhases, numOverrides);
+    qasm_recordNamedPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, NULL, 0, overrideInds, overridePhases, numOverrides);
 }
 
-void applyParamNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum phaseFunc functionNameCode, qreal* params, int numParams) {
+void applyParamNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, enum phaseFunc functionNameCode, qreal* params, int numParams) {
     validateStateVecQureg(qureg, __func__);
     validateQubitSubregs(qureg, qubits, numQubitsPerReg, numRegs, __func__);
+    validateMultiRegBitEncoding(numQubitsPerReg, numRegs, encoding, __func__);
     validatePhaseFuncName(functionNameCode, numParams, __func__);
 
-    statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, functionNameCode, params, numParams, NULL, NULL, 0);
+    statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, params, numParams, NULL, NULL, 0);
     
-    qasm_recordNamedPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, functionNameCode, params, numParams, NULL, NULL, 0);
+    qasm_recordNamedPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, params, numParams, NULL, NULL, 0);
 }
 
-void applyParamNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum phaseFunc functionNameCode, qreal* params, int numParams, long long int* overrideInds, qreal* overridePhases, int numOverrides) {
+void applyParamNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, enum phaseFunc functionNameCode, qreal* params, int numParams, long long int* overrideInds, qreal* overridePhases, int numOverrides) {
     validateStateVecQureg(qureg, __func__);
     validateQubitSubregs(qureg, qubits, numQubitsPerReg, numRegs, __func__);
+    validateMultiRegBitEncoding(numQubitsPerReg, numRegs, encoding, __func__);
     validatePhaseFuncName(functionNameCode, numParams, __func__);
-    validateMultiVarPhaseFuncOverrides(numQubitsPerReg, numRegs, overrideInds, numOverrides, __func__);
+    validateMultiVarPhaseFuncOverrides(numQubitsPerReg, numRegs, encoding, overrideInds, numOverrides, __func__);
 
-    statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, functionNameCode, params, numParams, overrideInds, overridePhases, numOverrides);
+    statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, params, numParams, overrideInds, overridePhases, numOverrides);
     
-    qasm_recordNamedPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, functionNameCode, params, numParams, overrideInds, overridePhases, numOverrides);
+    qasm_recordNamedPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, encoding, functionNameCode, params, numParams, overrideInds, overridePhases, numOverrides);
 }
 
 

--- a/QuEST/src/QuEST.c
+++ b/QuEST/src/QuEST.c
@@ -58,7 +58,6 @@ void applyTwoQubitMatrix(Qureg qureg, int targetQubit1, int targetQubit2, Comple
     qasm_recordComment(qureg, "Here, an undisclosed 2-qubit matrix was pre-multiplied.");
 }
 
-
 void applyPhaseFunc(Qureg qureg, int* qubits, int numQubits, qreal* coeffs, qreal* exponents, int numTerms) {
     validateStateVecQureg(qureg, __func__);
     validateMultiQubits(qureg, qubits, numQubits, __func__);
@@ -96,7 +95,6 @@ void applyMultiVarPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPer
     validateNumMultiVarPhaseFuncTerms(numTermsPerReg, numRegs, __func__);
     validateMultiVarPhaseFuncOverrides(numQubitsPerReg, numRegs, overrideInds, numOverrides, __func__);
 
-
     statevec_applyMultiVarPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, coeffs, exponents, numTermsPerReg, overrideInds, overridePhases, numOverrides);
     
     qasm_recordMultiVarPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, coeffs, exponents, numTermsPerReg, overrideInds, overridePhases, numOverrides);
@@ -105,22 +103,43 @@ void applyMultiVarPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPer
 void applyNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum phaseFunc functionNameCode) {
     validateStateVecQureg(qureg, __func__);
     validateQubitSubregs(qureg, qubits, numQubitsPerReg, numRegs, __func__);
-    validatePhaseFuncName(functionNameCode, __func__);
+    validatePhaseFuncName(functionNameCode, 0, __func__);
 
-    statevec_applyNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, functionNameCode, NULL, NULL, 0);
+    statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, functionNameCode, NULL, 0, NULL, NULL, 0);
     
-    qasm_recordNamedPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, functionNameCode, NULL, NULL, 0);
+    qasm_recordNamedPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, functionNameCode, NULL, 0, NULL, NULL, 0);
 }
 
 void applyNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum phaseFunc functionNameCode, long long int* overrideInds, qreal* overridePhases, int numOverrides) {
     validateStateVecQureg(qureg, __func__);
     validateQubitSubregs(qureg, qubits, numQubitsPerReg, numRegs, __func__);
-    validatePhaseFuncName(functionNameCode, __func__);
+    validatePhaseFuncName(functionNameCode, 0, __func__);
     validateMultiVarPhaseFuncOverrides(numQubitsPerReg, numRegs, overrideInds, numOverrides, __func__);
 
-    statevec_applyNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, functionNameCode, overrideInds, overridePhases, numOverrides);
+    statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, functionNameCode, NULL, 0, overrideInds, overridePhases, numOverrides);
     
-    qasm_recordNamedPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, functionNameCode, overrideInds, overridePhases, numOverrides);
+    qasm_recordNamedPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, functionNameCode, NULL, 0, overrideInds, overridePhases, numOverrides);
+}
+
+void applyParamNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum phaseFunc functionNameCode, qreal* params, int numParams) {
+    validateStateVecQureg(qureg, __func__);
+    validateQubitSubregs(qureg, qubits, numQubitsPerReg, numRegs, __func__);
+    validatePhaseFuncName(functionNameCode, numParams, __func__);
+
+    statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, functionNameCode, params, numParams, NULL, NULL, 0);
+    
+    qasm_recordNamedPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, functionNameCode, params, numParams, NULL, NULL, 0);
+}
+
+void applyParamNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum phaseFunc functionNameCode, qreal* params, int numParams, long long int* overrideInds, qreal* overridePhases, int numOverrides) {
+    validateStateVecQureg(qureg, __func__);
+    validateQubitSubregs(qureg, qubits, numQubitsPerReg, numRegs, __func__);
+    validatePhaseFuncName(functionNameCode, numParams, __func__);
+    validateMultiVarPhaseFuncOverrides(numQubitsPerReg, numRegs, overrideInds, numOverrides, __func__);
+
+    statevec_applyParamNamedPhaseFuncOverrides(qureg, qubits, numQubitsPerReg, numRegs, functionNameCode, params, numParams, overrideInds, overridePhases, numOverrides);
+    
+    qasm_recordNamedPhaseFunc(qureg, qubits, numQubitsPerReg, numRegs, functionNameCode, params, numParams, overrideInds, overridePhases, numOverrides);
 }
 
 

--- a/QuEST/src/QuEST_internal.h
+++ b/QuEST/src/QuEST_internal.h
@@ -26,7 +26,7 @@ void statevec_applyPhaseFuncOverrides(Qureg qureg, int* qubits, int numQubits, q
 
 void statevec_applyMultiVarPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, qreal* coeffs, qreal* exponents, int* numTermsPerReg, long long int* overrideInds, qreal* overridePhases, int numOverrides);
 
-void statevec_applyNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum phaseFunc functionNameCode, long long int* overrideInds, qreal* overridePhases, int numOverrides);
+void statevec_applyParamNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum phaseFunc functionNameCode, qreal* params, int numParams, long long int* overrideInds, qreal* overridePhases, int numOverrides);
 
 
 

--- a/QuEST/src/QuEST_internal.h
+++ b/QuEST/src/QuEST_internal.h
@@ -22,11 +22,11 @@ extern "C" {
 /*
  * added directly to QuESTlink
  */
-void statevec_applyPhaseFuncOverrides(Qureg qureg, int* qubits, int numQubits, qreal* coeffs, qreal* exponents, int numTerms, long long int* overrideInds, qreal* overridePhases, int numOverrides);
+void statevec_applyPhaseFuncOverrides(Qureg qureg, int* qubits, int numQubits, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int numTerms, long long int* overrideInds, qreal* overridePhases, int numOverrides);
 
-void statevec_applyMultiVarPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, qreal* coeffs, qreal* exponents, int* numTermsPerReg, long long int* overrideInds, qreal* overridePhases, int numOverrides);
+void statevec_applyMultiVarPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int* numTermsPerReg, long long int* overrideInds, qreal* overridePhases, int numOverrides);
 
-void statevec_applyParamNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum phaseFunc functionNameCode, qreal* params, int numParams, long long int* overrideInds, qreal* overridePhases, int numOverrides);
+void statevec_applyParamNamedPhaseFuncOverrides(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, enum phaseFunc functionNameCode, qreal* params, int numParams, long long int* overrideInds, qreal* overridePhases, int numOverrides);
 
 
 

--- a/QuEST/src/QuEST_qasm.c
+++ b/QuEST/src/QuEST_qasm.c
@@ -476,7 +476,7 @@ void qasm_recordInitClassical(Qureg qureg, long long int stateInd) {
             qasm_recordGate(qureg, GATE_SIGMA_X, q);
 }
 
-void qasm_recordPhaseFunc(Qureg qureg, int* qubits, int numQubits, qreal* coeffs, qreal* exponents, int numTerms, long long int* overrideInds, qreal* overridePhases, int numOverrides) {
+void qasm_recordPhaseFunc(Qureg qureg, int* qubits, int numQubits, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int numTerms, long long int* overrideInds, qreal* overridePhases, int numOverrides) {
     
     if (!qureg.qasmLog->isLogging)
         return;
@@ -498,7 +498,10 @@ void qasm_recordPhaseFunc(Qureg qureg, int* qubits, int numQubits, qreal* coeffs
         bufferOverflow();
     addStringToQASM(qureg, line, len);
     
-    qasm_recordComment(qureg, "  upon every substate |x>, informed by qubits");
+    char encBuf[MAX_LINE_LEN];
+    if (encoding == UNSIGNED)           sprintf(encBuf, "an unsigned");
+    if (encoding == TWOS_COMPLEMENT)    sprintf(encBuf, "a two's complement");
+    qasm_recordComment(qureg, "  upon every substate |x>, informed by qubits (under %s binary encoding)", encBuf);
     
     // record like:
     //     {0, 3, 2}
@@ -544,9 +547,12 @@ char getPhaseFuncSymbol(int numSymbs, int ind) {
     return 'x';
 }
 
-void addMultiVarRegsToQASM(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs) {
+void addMultiVarRegsToQASM(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding) {
     
-    qasm_recordComment(qureg, "  upon substates informed by qubits");
+    char encBuf[MAX_LINE_LEN];
+    if (encoding == UNSIGNED)           sprintf(encBuf, "an unsigned");
+    if (encoding == TWOS_COMPLEMENT)    sprintf(encBuf, "a two's complement");
+    qasm_recordComment(qureg, "  upon substates informed by qubits (under %s binary encoding)", encBuf);
     
     char line[MAX_LINE_LEN+1];
     int len = 0;
@@ -598,7 +604,8 @@ void addMultiVarOverridesToQASM(Qureg qureg, int numRegs, long long int* overrid
     }
 }
 
-void qasm_recordMultiVarPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, qreal* coeffs, qreal* exponents, int* numTermsPerReg, long long int* overrideInds, qreal* overridePhases, int numOverrides) {
+                                                                                            // TODO: parse encoding
+void qasm_recordMultiVarPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int* numTermsPerReg, long long int* overrideInds, qreal* overridePhases, int numOverrides) {
     
     if (!qureg.qasmLog->isLogging)
         return;
@@ -646,13 +653,14 @@ void qasm_recordMultiVarPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg
         addStringToQASM(qureg, line, len);
     }
     
-    addMultiVarRegsToQASM(qureg, qubits, numQubitsPerReg, numRegs);
+    addMultiVarRegsToQASM(qureg, qubits, numQubitsPerReg, numRegs, encoding);
     
     if (numOverrides > 0)
         addMultiVarOverridesToQASM(qureg, numRegs, overrideInds, overridePhases, numOverrides);
 }
 
-void qasm_recordNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum phaseFunc funcName, qreal* params, int numParams, long long int* overrideInds, qreal* overridePhases, int numOverrides) {
+                                                                                           // TODO: parse encoding
+void qasm_recordNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, enum phaseFunc funcName, qreal* params, int numParams, long long int* overrideInds, qreal* overridePhases, int numOverrides) {
     
     if (!qureg.qasmLog->isLogging)
         return;
@@ -685,7 +693,7 @@ void qasm_recordNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, i
         bufferOverflow();
     addStringToQASM(qureg, line, len);
     
-    addMultiVarRegsToQASM(qureg, qubits, numQubitsPerReg, numRegs);
+    addMultiVarRegsToQASM(qureg, qubits, numQubitsPerReg, numRegs, encoding);
     
     if (numOverrides > 0)
         addMultiVarOverridesToQASM(qureg, numRegs, overrideInds,overridePhases, numOverrides);

--- a/QuEST/src/QuEST_qasm.h
+++ b/QuEST/src/QuEST_qasm.h
@@ -69,11 +69,11 @@ void qasm_recordMultiControlledUnitary(Qureg qureg, ComplexMatrix2 u, int* contr
 
 void qasm_recordMultiStateControlledUnitary(Qureg qureg, ComplexMatrix2 u, int* controlQubits, int* controlState, const int numControlQubits, const int targetQubit);
 
-void qasm_recordPhaseFunc(Qureg qureg, int* qubits, int numQubits, qreal* coeffs, qreal* exponents, int numTerms, long long int* overrideInds, qreal* overridePhases, int numOverrides);
+void qasm_recordPhaseFunc(Qureg qureg, int* qubits, int numQubits, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int numTerms, long long int* overrideInds, qreal* overridePhases, int numOverrides);
 
-void qasm_recordMultiVarPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, qreal* coeffs, qreal* exponents, int* numTermsPerReg, long long int* overrideInds, qreal* overridePhases, int numOverrides);
+void qasm_recordMultiVarPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, qreal* coeffs, qreal* exponents, int* numTermsPerReg, long long int* overrideInds, qreal* overridePhases, int numOverrides);
 
-void qasm_recordNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum phaseFunc functionNameCode, qreal* params, int numParams, long long int* overrideInds, qreal* overridePhases, int numOverrides);
+void qasm_recordNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, enum phaseFunc functionNameCode, qreal* params, int numParams, long long int* overrideInds, qreal* overridePhases, int numOverrides);
 
 /* not actually used. D'oh!
 void qasm_recordMultiControlledAxisRotation(Qureg qureg, qreal angle, Vector axis, int* controlQubits, const int numControlQubits, const int targetQubit);\

--- a/QuEST/src/QuEST_qasm.h
+++ b/QuEST/src/QuEST_qasm.h
@@ -73,7 +73,7 @@ void qasm_recordPhaseFunc(Qureg qureg, int* qubits, int numQubits, qreal* coeffs
 
 void qasm_recordMultiVarPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, qreal* coeffs, qreal* exponents, int* numTermsPerReg, long long int* overrideInds, qreal* overridePhases, int numOverrides);
 
-void qasm_recordNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum phaseFunc functionNameCode, long long int* overrideInds, qreal* overridePhases, int numOverrides);
+void qasm_recordNamedPhaseFunc(Qureg qureg, int* qubits, int* numQubitsPerReg, int numRegs, enum phaseFunc functionNameCode, qreal* params, int numParams, long long int* overrideInds, qreal* overridePhases, int numOverrides);
 
 /* not actually used. D'oh!
 void qasm_recordMultiControlledAxisRotation(Qureg qureg, qreal angle, Vector axis, int* controlQubits, const int numControlQubits, const int targetQubit);\

--- a/QuEST/src/QuEST_validation.c
+++ b/QuEST/src/QuEST_validation.c
@@ -134,8 +134,8 @@ static const char* errorMessages[] = {
     [E_INVALID_NUM_PHASE_FUNC_TERMS] = "Invalid number of terms in the phase function specified. Must be >0.",
     [E_INVALID_NUM_PHASE_FUNC_OVERRIDES] = "Invalid number of phase function overrides specified. Must be >=0.",
     [E_INVALID_PHASE_FUNC_OVERRIDE_INDEX] = "Invalid phase function override index. Must be >=0, and <= the maximum index possible of the corresponding qubit subregister (2^numQubits-1).",
-    [E_INVALID_PHASE_FUNC_NAME] = "Invalid named phase function, which must be one of {NORM, INVERSE_NORM, SCALED_NORM, SCALED_INVERSE_NORM}.",
-    [E_INVALID_NUM_NAMED_PHASE_FUNC_PARAMS] = "Invalid number of parameters passed for the give named phase function. NORM and INVERSE_NORM accept 0 parameters, while SCALED_NORM and SCALED_INVERSE_NORM accept 1 parameter."
+    [E_INVALID_PHASE_FUNC_NAME] = "Invalid named phase function, which must be one of {NORM, INVERSE_NORM, SCALED_NORM, SCALED_INVERSE_NORM, SCALED_PRODUCT}.",
+    [E_INVALID_NUM_NAMED_PHASE_FUNC_PARAMS] = "Invalid number of parameters passed for the give named phase function. NORM and INVERSE_NORM accept 0 parameters, while SCALED_NORM, SCALED_INVERSE_NORM and SCALED_PRODUCT accept 1 parameter."
 };
 
 /* QuESTlink defines invalidQuESTInputError, so it doesn't need to be weakly 
@@ -571,15 +571,14 @@ void validatePhaseFuncName(enum phaseFunc funcCode, int numParams, const char* c
             funcCode == NORM || 
             funcCode == INVERSE_NORM ||
             funcCode == SCALED_NORM ||
-            funcCode == SCALED_INVERSE_NORM,
+            funcCode == SCALED_INVERSE_NORM ||
+            funcCode == SCALED_PRODUCT,
              E_INVALID_PHASE_FUNC_NAME, caller);
     
     if (funcCode == NORM || funcCode == INVERSE_NORM)
         QuESTAssert(numParams == 0, E_INVALID_NUM_NAMED_PHASE_FUNC_PARAMS, caller);
-    if (funcCode == SCALED_NORM || funcCode == SCALED_INVERSE_NORM)
+    if (funcCode == SCALED_NORM || funcCode == SCALED_INVERSE_NORM || funcCode == SCALED_PRODUCT)
         QuESTAssert(numParams == 1, E_INVALID_NUM_NAMED_PHASE_FUNC_PARAMS, caller);
-    
-    
 }
 
 #ifdef __cplusplus

--- a/QuEST/src/QuEST_validation.c
+++ b/QuEST/src/QuEST_validation.c
@@ -78,7 +78,8 @@ typedef enum {
     E_INVALID_NUM_PHASE_FUNC_TERMS,
     E_INVALID_NUM_PHASE_FUNC_OVERRIDES,
     E_INVALID_PHASE_FUNC_OVERRIDE_INDEX,
-    E_INVALID_PHASE_FUNC_NAME
+    E_INVALID_PHASE_FUNC_NAME,
+    E_INVALID_NUM_NAMED_PHASE_FUNC_PARAMS
 } ErrorCode;
 
 static const char* errorMessages[] = {
@@ -133,7 +134,8 @@ static const char* errorMessages[] = {
     [E_INVALID_NUM_PHASE_FUNC_TERMS] = "Invalid number of terms in the phase function specified. Must be >0.",
     [E_INVALID_NUM_PHASE_FUNC_OVERRIDES] = "Invalid number of phase function overrides specified. Must be >=0.",
     [E_INVALID_PHASE_FUNC_OVERRIDE_INDEX] = "Invalid phase function override index. Must be >=0, and <= the maximum index possible of the corresponding qubit subregister (2^numQubits-1).",
-    [E_INVALID_PHASE_FUNC_NAME] = "Invalid named phase function, which must be one of {NORM, INVERSE_NORM}."
+    [E_INVALID_PHASE_FUNC_NAME] = "Invalid named phase function, which must be one of {NORM, INVERSE_NORM, SCALED_NORM, SCALED_INVERSE_NORM}.",
+    [E_INVALID_NUM_NAMED_PHASE_FUNC_PARAMS] = "Invalid number of parameters passed for the give named phase function. NORM and INVERSE_NORM accept 0 parameters, while SCALED_NORM and SCALED_INVERSE_NORM accept 1 parameter."
 };
 
 /* QuESTlink defines invalidQuESTInputError, so it doesn't need to be weakly 
@@ -564,8 +566,20 @@ void validateMultiVarPhaseFuncOverrides(int* numQubitsPerReg, const int numRegs,
     }
 }
 
-void validatePhaseFuncName(enum phaseFunc funcCode, const char* caller) {
-    QuESTAssert(funcCode == NORM || funcCode == INVERSE_NORM, E_INVALID_PHASE_FUNC_NAME, caller);
+void validatePhaseFuncName(enum phaseFunc funcCode, int numParams, const char* caller) {
+    QuESTAssert(
+            funcCode == NORM || 
+            funcCode == INVERSE_NORM ||
+            funcCode == SCALED_NORM ||
+            funcCode == SCALED_INVERSE_NORM,
+             E_INVALID_PHASE_FUNC_NAME, caller);
+    
+    if (funcCode == NORM || funcCode == INVERSE_NORM)
+        QuESTAssert(numParams == 0, E_INVALID_NUM_NAMED_PHASE_FUNC_PARAMS, caller);
+    if (funcCode == SCALED_NORM || funcCode == SCALED_INVERSE_NORM)
+        QuESTAssert(numParams == 1, E_INVALID_NUM_NAMED_PHASE_FUNC_PARAMS, caller);
+    
+    
 }
 
 #ifdef __cplusplus

--- a/QuEST/src/QuEST_validation.h
+++ b/QuEST/src/QuEST_validation.h
@@ -101,15 +101,19 @@ void validateOneQubitDampingProb(qreal prob, const char* caller);
 
 void validateQubitSubregs(Qureg qureg, int* qubits, int* numQubitsPerReg, const int numReg, const char* caller);
 
-void validatePhaseFuncOverrides(const int numQubits, long long int* overrideInds, int numOverrides, const char* caller);
+void validatePhaseFuncOverrides(const int numQubits, enum bitEncoding encoding, long long int* overrideInds, int numOverrides, const char* caller);
 
-void validateMultiVarPhaseFuncOverrides(int* numQubitsPerReg, const int numRegs, long long int* overrideInds, int numOverrides, const char* caller);
+void validateMultiVarPhaseFuncOverrides(int* numQubitsPerReg, const int numRegs, enum bitEncoding encoding, long long int* overrideInds, int numOverrides, const char* caller);
 
 void validateNumPhaseFuncTerms(const int numTerms, const char* caller);
 
 void validateNumMultiVarPhaseFuncTerms(int* numTermsPerReg, const int numRegs, const char* caller);
 
 void validatePhaseFuncName(enum phaseFunc funcCode, int numParams, const char* caller);
+
+void validateBitEncoding(int numQubits, enum bitEncoding encoding, const char* caller);
+
+void validateMultiRegBitEncoding(int* numQubitsPerReg, int numRegs, enum bitEncoding encoding, const char* caller);
 
 # ifdef __cplusplus
 }

--- a/QuEST/src/QuEST_validation.h
+++ b/QuEST/src/QuEST_validation.h
@@ -109,9 +109,7 @@ void validateNumPhaseFuncTerms(const int numTerms, const char* caller);
 
 void validateNumMultiVarPhaseFuncTerms(int* numTermsPerReg, const int numRegs, const char* caller);
 
-
-
-void validatePhaseFuncName(enum phaseFunc funcCode, const char* caller);
+void validatePhaseFuncName(enum phaseFunc funcCode, int numParams, const char* caller);
 
 # ifdef __cplusplus
 }


### PR DESCRIPTION
- parameterised named phase functions
- `ScaledProduct` named phase function
- `BitEncoding` option
- "TwosComplement" bit encoding
- moved `PhaseOverrides` to optional arg
- tweaked `GetAmp` doc (specified indexing from zero)