### PR TITLE
added persistent work Quregs to derivatives

### DIFF
--- a/Link/QuESTlink.m
+++ b/Link/QuESTlink.m
@@ -55,7 +55,7 @@ Accepts optional arguments WithBackup and ShowProgress."
     ApplyCircuit::error = "`1`"
     
     CalcQuregDerivs::usage = "CalcQuregDerivs[circuit, initQureg, varVals, derivQuregs] modifies the given list of (deriv)quregs to be the result of applying derivatives of the parameterised circuit to the initial state. The derivQuregs are ordered by the varVals, which should be in the format {param -> value}, where param is featured in any continuous gate or decoherence channel.
-CalcQuregDerivs[circuit, initQureg, varVals, derivQuregs, workspaceQureg] uses the given persistent workspace qureg to avoid tediously creating and destroying any internal quregs, for a speedup.
+CalcQuregDerivs[circuit, initQureg, varVals, derivQuregs, workspaceQureg] uses the given persistent workspace qureg to avoid tediously creating and destroying any internal quregs, for a speedup. For convenience, any number of workspaces can be passed, but only the first is used.
 Variable repetition, multi-parameter gates, variable dependent element-wise matrices, variable dependent channels and operators whose parameters are (numerically evaluable) functions of variables are all permitted. In effect, every continuously-parameterised circuit or channel is permitted."
     CalcQuregDerivs::error = "`1`"
     
@@ -704,7 +704,7 @@ The probability of the forced measurement outcome (if hypothetically not forced)
          * derivatives
          *)
 
-        CalcQuregDerivs[circuit_?isCircuitFormat, initQureg_Integer, varVals:{(_ -> _?NumericQ) ..}, derivQuregs:{__Integer}, workQureg_Integer:-1] :=  
+        CalcQuregDerivs[circuit_?isCircuitFormat, initQureg_Integer, varVals:{(_ -> _?NumericQ) ..}, derivQuregs:{__Integer}, workQuregs:(_Integer|{__Integer}):-1] :=  
             Module[
                 {ret, encodedCirc, encodedDerivTerms},
                 (* check each var corresponds to a deriv qureg *)
@@ -716,11 +716,9 @@ The probability of the forced measurement outcome (if hypothetically not forced)
                     Message[CalcQuregDerivs::error, ret]; Return @ $Failed];
                 (* send to backend, mapping Mathematica indices to C++ indices *)
                 {encodedCirc, encodedDerivTerms} = ret;
-                CalcQuregDerivsInternal[initQureg, workQureg, derivQuregs, 
+                CalcQuregDerivsInternal[initQureg, First@{Sequence@@workQuregs}, derivQuregs, 
                     unpackEncodedCircuit @ encodedCirc, 
                     unpackEncodedDerivCircTerms @ encodedDerivTerms]]
-        CalcQuregDerivs[circuit_?isCircuitFormat, initQureg_Integer, varVals:{(_ -> _?NumericQ) ..}, derivQuregs:{__Integer}, {workQureg_Integer}] :=  
-            CalcQuregDerivs[circuit, initQureg, varVals, derivQuregs, workQureg]
         CalcQuregDerivs[___] := invalidArgError[CalcQuregDerivs]
         
         isPureCircuit[circuit_] := 

--- a/Link/circuits.cpp
+++ b/Link/circuits.cpp
@@ -137,6 +137,30 @@ bool Gate::isUnitary() {
     }
 }
 
+bool Gate::isPure() {
+    
+    if (isUnitary())
+        return true;
+    
+    switch(opcode) {
+        
+        case OPCODE_M :
+        case OPCODE_P :
+        case OPCODE_Matr :
+            return true;
+        
+        case OPCODE_Deph :
+        case OPCODE_Depol :
+        case OPCODE_Damp :
+        case OPCODE_Kraus :
+        case OPCODE_KrausNonTP :
+            return false;
+                  
+        default:            
+            throw QuESTException("", "an unrecognised gate was queried for purity. This is likely an internal error."); // throws
+    }
+}
+
 void Gate::applyTo(Qureg qureg, qreal* outputs) {
     
     switch(opcode) {
@@ -706,6 +730,15 @@ bool Circuit::isUnitary() {
     
     for (int i=0; i<numGates; i++)
         if (! gates[i].isUnitary())
+            return false;
+            
+    return true;
+}
+
+bool Circuit::isPure() {
+    
+    for (int i=0; i<numGates; i++)
+        if (!gates[i].isPure())
             return false;
             
     return true;

--- a/Link/circuits.hpp
+++ b/Link/circuits.hpp
@@ -118,6 +118,12 @@ class Gate {
          * (such as Rx, H, U, UNonNorm), or not (like M, P, Matr, Damp)
          */
         bool isUnitary();
+        
+        /** Returns whether the gate is pure, i.e. can be performed upon 
+         * statevectors (true), else whether it can only be performed upon 
+         * density matrices (false)
+         */
+        bool isPure();
             
         /** Returns the number of outputs that this gate produces when performed 
          * in a circuit. This is the number of elements added to the outputs array 
@@ -219,6 +225,12 @@ class Circuit {
          * U, UNonNorm, Rx, etc) as opposed to non-unitaries (like Matr, P, M, Damp)
          */
         bool isUnitary();
+        
+        /** Returns whether the circuit contains only pure gates and can hence be 
+         * performed upon  statevectors (true), else whether it can only be performed 
+         * upon density matrices (false)
+         */
+        bool isPure();
         
         /** Modify qureg by sequentially applying every gate within the circuit, 
          * with increasing index. Array outputs is modified to have its first n 

--- a/Link/derivatives.cpp
+++ b/Link/derivatives.cpp
@@ -401,125 +401,107 @@ void DerivCircuit::applyTo(Qureg* quregs, int numQuregs, Qureg initQureg, Qureg 
     }
 }
 
-void DerivCircuit::calcDerivEnergiesStateVec(qreal* eneryGrad, PauliHamil hamil, Qureg initQureg) {
+void DerivCircuit::calcDerivEnergiesStateVec(qreal* eneryGrad, PauliHamil hamil, Qureg initQureg, Qureg* workQuregs, int numWorkQuregs) {
     
     if (!circuit->isUnitary())
         throw QuESTException("", "The given circuit must be composed strictly of invertible gates "
             "(and ergo exclude gates like Matr[] and P[]), in order to return a valid real "
             "observable gradient. Please instead use CalcQuregDerivs[]"); // throws
+            
+    if (numWorkQuregs < 3)
+        throw QuESTException("", "An internal error occured. Fewer than three working registers were "
+            "passed to DerivCircuit::calcDerivEnergiesStateVec, despite prior validation."); // throws
+        
+    Qureg workLambda = workQuregs[0];
+    Qureg workPhi    = workQuregs[1];
+    Qureg workMu     = workQuregs[2];
     
-    // prepare lambda = H circuit(init) and phi=circuit(init)
-    Qureg workLambda = createCloneQureg(initQureg, env);
-    circuit->applyTo(workLambda);
-    Qureg workPhi = createCloneQureg(workLambda, env);
-    applyPauliHamil(workPhi, hamil, workLambda);
-    
-    // prepare workMu in arbitrary state
-    Qureg workMu = createQureg(initQureg.numQubitsRepresented, env);
+    // prepare |lambda> = H circuit |init> and |phi> = circuit |init>
+    cloneQureg(workLambda, initQureg);
+    circuit->applyTo(workLambda); // throws
+    cloneQureg(workPhi, workLambda);
+    applyPauliHamil(workPhi, hamil, workLambda); // throws
 
     // clear energies
     for (int i=0; i<numVars; i++)
         eneryGrad[i] = 0;
-        
-    // explicitly catch and rethrow errors to force clean-up of above quregs
-    try {
-        
-        for (int t=numTerms-1; t>=0; t--) {
-            
-            DerivTerm derivTerm = terms[t];
-            int gateInd = derivTerm.getGateInd();
-            int varInd = derivTerm.getVarInd();
-            
-            // remove all gates >= gateInd (not removed by previous iteration) from workPhi
-            circuit->applyDaggerSubTo(workPhi, gateInd, 
-                (t<numTerms-1)? terms[t+1].getGateInd() : circuit->getNumGates());
 
-            // add all (daggered) gates > gateInd (not added by previous iteration) to workLambda
-            circuit->applyDaggerSubTo(workLambda, gateInd + 1,
-                (t<numTerms-1)? terms[t+1].getGateInd() + 1 : circuit->getNumGates());
-                
-            cloneQureg(workMu, workPhi);
-            derivTerm.applyTo(workMu);
-            eneryGrad[varInd] += 2 * calcInnerProduct(workLambda, workMu).real;        
-        }
+    for (int t=numTerms-1; t>=0; t--) {
         
-    } catch (QuESTException& err) {
+        DerivTerm derivTerm = terms[t];
+        int gateInd = derivTerm.getGateInd();
+        int varInd = derivTerm.getVarInd();
         
-        // clean-up and rethrow
-        destroyQureg(workLambda, env);
-        destroyQureg(workPhi, env);
-        destroyQureg(workMu, env);
-        throw;
+        // remove all gates >= gateInd (not removed by previous iteration) from workPhi
+        circuit->applyDaggerSubTo(workPhi, gateInd, 
+            (t<numTerms-1)? terms[t+1].getGateInd() : circuit->getNumGates()); // throws
+
+        // add all (daggered) gates > gateInd (not added by previous iteration) to workLambda
+        circuit->applyDaggerSubTo(workLambda, gateInd + 1,
+            (t<numTerms-1)? terms[t+1].getGateInd() + 1 : circuit->getNumGates()); // throws
+            
+        cloneQureg(workMu, workPhi);
+        derivTerm.applyTo(workMu); // throws
+        eneryGrad[varInd] += 2 * calcInnerProduct(workLambda, workMu).real;        
     }
-    
-    // clean-up
-    destroyQureg(workLambda, env);
-    destroyQureg(workPhi, env);
-    destroyQureg(workMu, env);
 }
 
-void DerivCircuit::calcDerivEnergiesDensMatr(qreal* energyGrad, PauliHamil hamil, Qureg initQureg) {
+void DerivCircuit::calcDerivEnergiesDensMatr(qreal* energyGrad, PauliHamil hamil, Qureg initQureg, Qureg* workQuregs, int numWorkQuregs) {
     
-    // initQureg may be a statevector or a density matrix
-    Qureg qureg = createDensityQureg(initQureg.numQubitsRepresented, env);
-    Qureg workspace = createCloneQureg(qureg, env);
+    if (numWorkQuregs < 2)
+        throw QuESTException("", "An internal error occured. Fewer than two working registers were "
+            "passed to DerivCircuit::calcDerivEnergiesDensMatr, despite prior validation."); // throws
+    
+    Qureg qureg     = workQuregs[0];
+    Qureg workspace = workQuregs[1];
     
     // clear energies
     for (int i=0; i<numVars; i++)
         energyGrad[i] = 0;
-    
-    // explicitly catch and rethrow errors to force clean-up of above quregs
-    try {
         
-        // iterate each differential term (those produced after chain-rule expansion)
-        for (int t=0; t<numTerms; t++) {
-            
-            DerivTerm term = terms[t];
-            int gateInd = term.getGateInd();
-            int varInd = term.getVarInd();
-            
-            // set qureg = initQureg
-            if (initQureg.isDensityMatrix)
-                cloneQureg(qureg, initQureg);
-            else
-                initPureState(qureg, initQureg);
-            
-            // produce a single term of (d circuit(qureg) / d var)
-            circuit->applySubTo(qureg, 0, gateInd); // throws
-            term.applyTo(qureg); // throws
-            circuit->applySubTo(qureg, gateInd+1, circuit->getNumGates()); // throws
-            
-            // add this term to (d circuit(qureg) / d var)
-            energyGrad[varInd] += calcExpecPauliHamil(qureg, hamil, workspace);
-        }
+    // iterate each differential term (those produced after chain-rule expansion)
+    for (int t=0; t<numTerms; t++) {
         
-    } catch (QuESTException& err) {
+        DerivTerm term = terms[t];
+        int gateInd = term.getGateInd();
+        int varInd = term.getVarInd();
         
-        // clean-up and rethrow
-        destroyQureg(qureg, env);
-        destroyQureg(workspace, env);
-        throw;
+        // set qureg = initQureg
+        if (initQureg.isDensityMatrix)
+            cloneQureg(qureg, initQureg);
+        else
+            initPureState(qureg, initQureg);
+        
+        // produce a single term of (d circuit(qureg) / d var)
+        circuit->applySubTo(qureg, 0, gateInd); // throws
+        term.applyTo(qureg); // throws
+        circuit->applySubTo(qureg, gateInd+1, circuit->getNumGates()); // throws
+        
+        // add this term to (d circuit(qureg) / d var)
+        energyGrad[varInd] += calcExpecPauliHamil(qureg, hamil, workspace);
     }
-
-    // clean-up
-    destroyQureg(qureg, env);
-    destroyQureg(workspace, env);
 }
 
-void DerivCircuit::calcDerivEnergies(qreal* energyGrad, PauliHamil hamil, Qureg initQureg, bool isPureCirc) {
+void DerivCircuit::calcDerivEnergies(qreal* energyGrad, PauliHamil hamil, Qureg initQureg, Qureg* workQuregs, int numWorkQuregs) {
     
-    if (isPureCirc && !initQureg.isDensityMatrix)
-        calcDerivEnergiesStateVec(energyGrad, hamil, initQureg);
+    if (circuit->isPure() && !initQureg.isDensityMatrix)
+        calcDerivEnergiesStateVec(energyGrad, hamil, initQureg, workQuregs, numWorkQuregs);
     else
-        calcDerivEnergiesDensMatr(energyGrad, hamil, initQureg);
+        calcDerivEnergiesDensMatr(energyGrad, hamil, initQureg, workQuregs, numWorkQuregs);
 }
 
-void DerivCircuit::calcGeometricTensorStateVec(qcomp** tensor, Qureg initQureg) {
+void DerivCircuit::calcGeometricTensorStateVec(qcomp** tensor, Qureg initQureg, Qureg* workQuregs, int numWorkQuregs) {
     
-    Qureg quregDiag = createCloneQureg(initQureg, env);
-    Qureg quregSuffix = createCloneQureg(initQureg, env);
-    Qureg quregPrefix = createCloneQureg(initQureg, env);
-    Qureg quregDeriv = createCloneQureg(initQureg, env);
+    if (numWorkQuregs < 4)
+        throw QuESTException("", "An internal error occured. Fewer than four working registers were "
+            "passed to DerivCircuit::calcGeometricTensorStateVec, despite prior validation."); // throws
+    
+    Qureg quregDiag   = workQuregs[0];
+    Qureg quregSuffix = workQuregs[1];
+    Qureg quregPrefix = workQuregs[2];
+    Qureg quregDeriv  = workQuregs[3];
+    
+    cloneQureg(quregDiag, initQureg);
     
     // clear tensor
     for (int i=0; i<numVars; i++)
@@ -604,22 +586,14 @@ void DerivCircuit::calcGeometricTensorStateVec(qcomp** tensor, Qureg initQureg) 
         
         // clean-up and rethrow
         free(berries);
-        destroyQureg(quregDiag, env);
-        destroyQureg(quregSuffix, env);
-        destroyQureg(quregPrefix, env);
-        destroyQureg(quregDeriv, env);
         throw;
     }
 
     // clean-up
     free(berries);
-    destroyQureg(quregDiag, env);
-    destroyQureg(quregSuffix, env);
-    destroyQureg(quregPrefix, env);
-    destroyQureg(quregDeriv, env);
 }
 
-void DerivCircuit::calcGeometricTensorDensMatr(qcomp** tensor, Qureg initQureg) {
+void DerivCircuit::calcGeometricTensorDensMatr(qcomp** tensor, Qureg initQureg, Qureg* workQuregs, int numWorkQuregs) {
     
     /* TODO:
      * Implement quantum Fisher information matrix?
@@ -630,12 +604,66 @@ void DerivCircuit::calcGeometricTensorDensMatr(qcomp** tensor, Qureg initQureg) 
     throw QuESTException("", "This facility is not yet available for channels or density matrices.");
 }
 
-void DerivCircuit::calcGeometricTensor(qcomp** tensor, Qureg initQureg, bool isPureCirc) {
+void DerivCircuit::calcGeometricTensor(qcomp** tensor, Qureg initQureg, Qureg* workQuregs, int numWorkQuregs) {
     
-    if (isPureCirc &&  !initQureg.isDensityMatrix)
-        calcGeometricTensorStateVec(tensor, initQureg); // throws
+    if (circuit->isPure() && !initQureg.isDensityMatrix)
+        calcGeometricTensorStateVec(tensor, initQureg, workQuregs, numWorkQuregs); // throws
     else
-        calcGeometricTensorDensMatr(tensor, initQureg); // throws
+        calcGeometricTensorDensMatr(tensor, initQureg, workQuregs, numWorkQuregs); // throws
+}
+
+int DerivCircuit::getNumNeededWorkQuregsFor(std::string funcName, Qureg initQureg) {
+    
+    int circIsPure = circuit->isPure();
+    
+    if (funcName == "applyTo")
+        return 1;
+    
+    if (funcName == "calcDerivEnergies") {
+        
+        if (circIsPure && !initQureg.isDensityMatrix)
+            return 3;
+        else
+            return 2;
+    }
+    
+    if (funcName == "calcGeometricTensor") {
+        
+        if (circIsPure && !initQureg.isDensityMatrix)
+            return 4;
+        else
+            return 0; // TODO: update this when density matrix version implemented
+    }
+    
+    local_sendErrorAndFail("CalcQuregDerivs", "An irrevocable internal error occured (DerivCircuit::getNumNeededWorkQuregsFor() " 
+        "was given an unrecognised funcName: " + funcName + ") and the QuESTlink process must crash.");
+    throw QuESTException("", "An internal error occurred; the function named passed to getNumNeededWorkQuregsFor() was unrecognised."); // throws
+}
+
+void DerivCircuit::validateWorkQuregsFor(std::string methodName, int initQuregId, int* workQuregIds, int numWorkQuregs) {
+    
+    // no working registers is fine; they will be internally created
+    if (numWorkQuregs == 0)
+        return;
+        
+    int numNeeded = getNumNeededWorkQuregsFor(methodName, quregs[initQuregId]); // throws
+    if (numWorkQuregs < numNeeded)
+        throw QuESTException("", "Too few working registers were passed (" + std::to_string(numNeeded) + " are required)."); // throws
+        
+    for (int i=0; i<numWorkQuregs; i++) {
+        
+        int workspaceId = workQuregIds[i];
+        local_throwExcepIfQuregNotCreated(workspaceId); // throws
+        
+        if (workspaceId == initQuregId) 
+            throw QuESTException("", "The initial state qureg must not be included in the workspace quregs."); // throws
+            
+        int numQb = quregs[initQuregId].numQubitsRepresented;
+        int isDens = quregs[initQuregId].isDensityMatrix;
+        
+        if (quregs[workspaceId].numQubitsRepresented != numQb || quregs[workspaceId].isDensityMatrix != isDens)
+            throw QuESTException("", "Workspace quregs must have the same type and dimension as the initial state qureg."); // throws
+    }        
 }
 
 DerivCircuit::~DerivCircuit() {
@@ -656,7 +684,7 @@ void internal_calcQuregDerivs(int initQuregId, int workspaceId) {
     // get qureg ids (one for each var)
     int* quregIds;
     int numQuregs;
-    WSGetInteger32List(stdlink, &quregIds, &numQuregs); // must free
+    WSGetInteger32List(stdlink, &quregIds, &numQuregs);
     
     // load the circuit and derivative descriptions (local so no need to explicitly delete)
     DerivCircuit derivCirc;
@@ -667,19 +695,17 @@ void internal_calcQuregDerivs(int initQuregId, int workspaceId) {
         
         // validate initial state
         local_throwExcepIfQuregNotCreated(initQuregId); // throws
-        int numQb = quregs[initQuregId].numQubitsRepresented;
-        int isDens = quregs[initQuregId].isDensityMatrix;
         
         // validate workspace (if pre-allocated)
         if (workspaceId != -1) {
-            local_throwExcepIfQuregNotCreated(workspaceId); // throws
-            if (workspaceId == initQuregId) 
-                throw QuESTException("", "The initial state qureg must not also be the workspace qureg."); // throws
-            if (quregs[workspaceId].numQubitsRepresented != numQb || quregs[workspaceId].isDensityMatrix != isDens)
-                throw QuESTException("", "The workspace qureg must have the same type and dimension as the initial state qureg"); // throws 
+            int workspaces[] = {workspaceId}; // hacky integration into validateWorkQuregsFor(), due to design indecision
+            derivCirc.validateWorkQuregsFor("applyTo", initQuregId, workspaces, 1);
         }
             
-        // validate derivative registers
+        // validate derivative registers (no check of uniqueness)
+        int numQb = quregs[initQuregId].numQubitsRepresented;
+        int isDens = quregs[initQuregId].isDensityMatrix;
+            
         for (int q=0; q<numQuregs; q++) {
             local_throwExcepIfQuregNotCreated(quregIds[q]); // throws
             if (quregIds[q] == initQuregId)
@@ -695,7 +721,7 @@ void internal_calcQuregDerivs(int initQuregId, int workspaceId) {
     } catch (QuESTException& err) {
         local_sendErrorAndFail("CalcQuregDerivs", err.message);
         
-        // safely exit, no memory leaked (destructors auto-called)
+        WSReleaseInteger32List(stdlink, quregIds, numQuregs);
         return;
     }
     
@@ -731,12 +757,17 @@ void internal_calcQuregDerivs(int initQuregId, int workspaceId) {
     
     // clean-up even in event of error 
     free(derivQuregs);
-    
+    WSReleaseInteger32List(stdlink, quregIds, numQuregs);
     if (workspaceId == -1)
         destroyQureg(workspace, env);
 }
 
-void internal_calcExpecPauliStringDerivs(int initQuregId, int isPureCirc) {
+void internal_calcExpecPauliStringDerivs(int initQuregId) {
+    
+    // load the any-length workspace list from MMA
+    int* workQuregIds;
+    int numPassedWorkQuregs;
+    WSGetInteger32List(stdlink, &workQuregIds, &numPassedWorkQuregs);
     
     // load the circuit and deriv spec from MMA
     DerivCircuit derivCirc;
@@ -750,15 +781,41 @@ void internal_calcExpecPauliStringDerivs(int initQuregId, int isPureCirc) {
     } catch (QuESTException& err) {
         
         local_sendErrorAndFail("CalcExpecPauliStringDerivs", err.message);
+        WSReleaseInteger32List(stdlink, workQuregIds, numPassedWorkQuregs);
         return;
     }
     
+    // validate registers 
+    try {
+        if (numPassedWorkQuregs > 0)
+            derivCirc.validateWorkQuregsFor("calcDerivEnergies", initQuregId, workQuregIds, numPassedWorkQuregs); // throws
+            
+    } catch (QuESTException& err) {
+        
+        local_sendErrorAndFail("CalcExpecPauliStringDerivs", err.message);
+        WSReleaseInteger32List(stdlink, workQuregIds, numPassedWorkQuregs);
+        local_freePauliHamil(hamil);
+        return;
+    }
+    
+    Qureg initQureg = quregs[initQuregId];
+    
+    // optionally create work registers
+    int numNeededWorkQuregs = derivCirc.getNumNeededWorkQuregsFor("calcDerivEnergies", initQureg);
+    Qureg* workQuregs = (Qureg*) malloc(numNeededWorkQuregs * sizeof *workQuregs);
+    for (int i=0; i<numNeededWorkQuregs; i++)
+        if (numPassedWorkQuregs == 0)
+            workQuregs[i] = createCloneQureg(initQureg, env);
+        else
+            workQuregs[i] = quregs[workQuregIds[i]];
+            
     // prepare energy grad vector (malloc onto heap to avoid stack size limits)
     int numDerivs = derivCirc.getNumVars();
     qreal* energyGrad = (qreal*) malloc(numDerivs * sizeof *energyGrad);
     
     try {    
-        derivCirc.calcDerivEnergies(energyGrad, hamil, quregs[initQuregId], isPureCirc); // throws
+        // calc and return energy grad
+        derivCirc.calcDerivEnergies(energyGrad, hamil, initQureg, workQuregs, numNeededWorkQuregs); // throws
         
         WSPutReal64List(stdlink, energyGrad, numDerivs);
         
@@ -768,15 +825,50 @@ void internal_calcExpecPauliStringDerivs(int initQuregId, int isPureCirc) {
     }
 
     // clean-up even despite errors
+    if (numPassedWorkQuregs == 0)
+        for (int i=0; i<numNeededWorkQuregs; i++)
+            destroyQureg(workQuregs[i], env);
+    free(workQuregs);
     free(energyGrad);
     local_freePauliHamil(hamil);
+    WSReleaseInteger32List(stdlink, workQuregIds, numPassedWorkQuregs);
 }
 
-void internal_calcGeometricTensor(int initQuregId, int isPureCirc) {
+void internal_calcGeometricTensor(int initQuregId) {
+    
+    // load the any-length workspace list from MMA
+    int* workQuregIds;
+    int numPassedWorkQuregs;
+    WSGetInteger32List(stdlink, &workQuregIds, &numPassedWorkQuregs);
     
     // load the circuit and deriv spec from MMA
     DerivCircuit derivCirc;
     derivCirc.loadFromMMA(); // local, so desconstructor automatic
+    
+    // validate registers 
+    try {
+        local_throwExcepIfQuregNotCreated(initQuregId); // throws
+        
+        if (numPassedWorkQuregs > 0)
+            derivCirc.validateWorkQuregsFor("calcGeometricTensor", initQuregId, workQuregIds, numPassedWorkQuregs); // throws
+            
+    } catch (QuESTException& err) {
+        
+        local_sendErrorAndFail("CalcGeometricTensor", err.message);
+        WSReleaseInteger32List(stdlink, workQuregIds, numPassedWorkQuregs);
+        return;
+    }
+    
+    Qureg initQureg = quregs[initQuregId];
+    
+    // optionally create work registers
+    int numNeededWorkQuregs = derivCirc.getNumNeededWorkQuregsFor("calcGeometricTensor", initQureg);
+    Qureg* workQuregs = (Qureg*) malloc(numNeededWorkQuregs * sizeof *workQuregs);
+    for (int i=0; i<numNeededWorkQuregs; i++)
+        if (numPassedWorkQuregs == 0)
+            workQuregs[i] = createCloneQureg(initQureg, env);
+        else
+            workQuregs[i] = quregs[workQuregIds[i]];
     
     int tensorDim = derivCirc.getNumVars();
     qcomp** tensor = (qcomp**) malloc(tensorDim * sizeof *tensor);
@@ -784,10 +876,7 @@ void internal_calcGeometricTensor(int initQuregId, int isPureCirc) {
         tensor[i] = (qcomp*) malloc(tensorDim * sizeof **tensor);
     
     try {
-        
-        local_throwExcepIfQuregNotCreated(initQuregId); // throws
-
-        derivCirc.calcGeometricTensor(tensor, quregs[initQuregId], isPureCirc); // throws
+        derivCirc.calcGeometricTensor(tensor, initQureg, workQuregs, numNeededWorkQuregs); // throws
         
         local_sendMatrixToMMA(tensor, tensorDim);
     
@@ -797,7 +886,12 @@ void internal_calcGeometricTensor(int initQuregId, int isPureCirc) {
     }
     
     // clean-up, even if error
+    if (numPassedWorkQuregs == 0)
+        for (int i=0; i<numNeededWorkQuregs; i++)
+            destroyQureg(workQuregs[i], env);
+    free(workQuregs);
     for (int i=0; i<tensorDim; i++)
         free(tensor[i]);
     free(tensor);
+    WSReleaseInteger32List(stdlink, workQuregIds, numPassedWorkQuregs);
 }

--- a/Link/derivatives.hpp
+++ b/Link/derivatives.hpp
@@ -125,11 +125,11 @@ class DerivCircuit {
          * @precondition varInds between all terms lie in [0, numQuregs)
          * @precondition numQuregs = number of unique varInd between terms
          * @precondition gateInd between terms is increasing (or repeating)
-         * @precondition all quregs are initialised, and of equal dimension & type
+         * @precondition all quregs are created, and of equal dimension & type
          * @throws QuESTException if the circuit of deriv info is invalid 
          *         (i.e. contains invalid gate details), or if the user aborts
          */
-        void applyTo(Qureg* quregs, int numQuregs, Qureg initQureg);
+        void applyTo(Qureg* quregs, int numQuregs, Qureg initQureg, Qureg workspace);
         
         /** Modifies eneryGrad to be the gradient of the expected energy under
          * the given Hamiltonian, as prescribed by the circuit derivatives.

--- a/Link/derivatives.hpp
+++ b/Link/derivatives.hpp
@@ -94,10 +94,10 @@ class DerivCircuit {
         
         /** Qureg type-specific implementations of public methods 
          */
-        void calcDerivEnergiesStateVec(qreal* energies, PauliHamil hamil, Qureg initQureg);
-        void calcDerivEnergiesDensMatr(qreal* energies, PauliHamil hamil, Qureg initQureg);
-        void calcGeometricTensorStateVec(qcomp** tensor, Qureg initQureg);
-        void calcGeometricTensorDensMatr(qcomp** tensor, Qureg initQureg);
+        void calcDerivEnergiesStateVec(qreal* energies, PauliHamil hamil, Qureg initQureg, Qureg* workQuregs, int numWorkQuregs);
+        void calcDerivEnergiesDensMatr(qreal* energies, PauliHamil hamil, Qureg initQureg, Qureg* workQuregs, int numWorkQuregs);
+        void calcGeometricTensorStateVec(qcomp** tensor, Qureg initQureg, Qureg* workQuregs, int numWorkQuregs);
+        void calcGeometricTensorDensMatr(qcomp** tensor, Qureg initQureg, Qureg* workQuregs, int numWorkQuregs);
         
         /** Destroys the MMA arrays shared between DerivTerm instances (derivPArams), 
          * invoked during the destructor. This method is defined in decoders.cpp.
@@ -133,23 +133,32 @@ class DerivCircuit {
         
         /** Modifies eneryGrad to be the gradient of the expected energy under
          * the given Hamiltonian, as prescribed by the circuit derivatives.
-         * If initQureg is a state-vector, and isPureCirc = true, then this 
+         * If initQureg is a state-vector and the circuit is pure, then this 
          * function uses the O(#parameters) algorithm from arXiv 2009.02823.
          * Otherwise, it uses a O(#parameters^2) method. In both scenarios, 
          * the memory overhead is fixed. 
          * @param energyGrad must be a pre-allocated length-numVars array
-         * @param isPureCirc indicates whether the circuit contains only statevector gates
          */ 
-        void calcDerivEnergies(qreal* energyGrad, PauliHamil hamil, Qureg initQureg, bool isPureCirc);
+        void calcDerivEnergies(qreal* energyGrad, PauliHamil hamil, Qureg initQureg, Qureg* workQuregs, int numWorkQuregs);
         
         /** Modifies tensor to be the quantum geometric tensor prescribed by 
          * the circuit derivatives. This relates to the Fubini-Study metric, 
          * the classical Fisher information metric, and the imaginary-time Li 
          * tensor, and appears in pure-state quantum natural gradient.
          * @param energyGrad must be a pre-allocated 2D length-numVars array
-         * @param isPureCirc indicates whether the circuit contains only statevector gates
          */
-        void calcGeometricTensor(qcomp** tensor, Qureg initQureg, bool isPureCirc);
+        void calcGeometricTensor(qcomp** tensor, Qureg initQureg, Qureg* workQuregs, int numWorkQuregs);
+        
+        /** Returns the number of working registers needed to perform the method 
+         * indicated by funcName upon given the initial register.
+         */
+        int getNumNeededWorkQuregsFor(std::string funcName, Qureg initQureg);
+        
+        /** Throws an exception if the workQuregIds are invalid or if there are too 
+         * few for the given method.
+         * @precondition initQuregId must be valid
+         */
+        void validateWorkQuregsFor(std::string methodName, int initQuregId, int* workQuregIds, int numWorkQuregs);
         
         /** Destructor will free the persistent Mathematica arrays accesssed by 
          * the DerivTerm instances, as well as the Circuit. 

--- a/Link/templates.tm
+++ b/Link/templates.tm
@@ -440,21 +440,21 @@
 
 :Begin:
 :Function:       internal_calcExpecPauliStringDerivs
-:Pattern:        QuEST`Private`CalcExpecPauliStringDerivsInternal[initStateId_Integer, isPureCirc_Integer, opcodes_List, ctrls_List, numCtrlsPerOp_List, targs_List, numTargsPerOp_List, params_List, numParamsPerOp_List, derivOpInds_List, derivVarInds_List, derivParams_List, numDerivParamsPerDerivOp_List, termCoeffs_List, allPauliCodes_List, allPauliTargets_List, numPaulisPerTerm_List]
-:Arguments:      { initStateId, isPureCirc, opcodes, ctrls, numCtrlsPerOp, targs, numTargsPerOp, params, numParamsPerOp, derivOpInds, derivVarInds, derivParams, numDerivParamsPerDerivOp, termCoeffs, allPauliCodes, allPauliTargets, numPaulisPerTerm }
-:ArgumentTypes:  { Integer, Integer, Manual }
+:Pattern:        QuEST`Private`CalcExpecPauliStringDerivsInternal[initStateId_Integer, workspaces_List, opcodes_List, ctrls_List, numCtrlsPerOp_List, targs_List, numTargsPerOp_List, params_List, numParamsPerOp_List, derivOpInds_List, derivVarInds_List, derivParams_List, numDerivParamsPerDerivOp_List, termCoeffs_List, allPauliCodes_List, allPauliTargets_List, numPaulisPerTerm_List]
+:Arguments:      { initStateId, workspaces, opcodes, ctrls, numCtrlsPerOp, targs, numTargsPerOp, params, numParamsPerOp, derivOpInds, derivVarInds, derivParams, numDerivParamsPerDerivOp, termCoeffs, allPauliCodes, allPauliTargets, numPaulisPerTerm }
+:ArgumentTypes:  { Integer, Manual }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`Private`CalcExpecPauliStringDerivsInternal::usage = "CalcExpecPauliStringDerivsInternal[initStateId, isPureCirc, opcodes, ctrls, numCtrlsPerOp, targs, numTargsPerOp, params, numParamsPerOp, derivOpInds, derivVarInds, derivParams, numDerivParamsPerDerivOp, termCoeffs, allPauliCodes, allPauliTargets, numPaulisPerTerm] accepts a circuit (complete with rotation angles), a derivative specification, and a Hamiltonian, and returns the energy gradient."
+:Evaluate: QuEST`Private`CalcExpecPauliStringDerivsInternal::usage = "CalcExpecPauliStringDerivsInternal[initStateId, workspaces, opcodes, ctrls, numCtrlsPerOp, targs, numTargsPerOp, params, numParamsPerOp, derivOpInds, derivVarInds, derivParams, numDerivParamsPerDerivOp, termCoeffs, allPauliCodes, allPauliTargets, numPaulisPerTerm] accepts a circuit (complete with rotation angles), a derivative specification, and a Hamiltonian, and returns the energy gradient. workspaces can be a list of any length"
 
 :Begin:
 :Function:       internal_calcGeometricTensor
-:Pattern:        QuEST`Private`CalcGeometricTensorInternal[initStateId_Integer, isPureCirc_Integer, opcodes_List, ctrls_List, numCtrlsPerOp_List, targs_List, numTargsPerOp_List, params_List, numParamsPerOp_List, derivOpInds_List, derivVarInds_List, derivParams_List, numDerivParamsPerDerivOp_List]
-:Arguments:      { initStateId, isPureCirc, opcodes, ctrls, numCtrlsPerOp, targs, numTargsPerOp, params, numParamsPerOp, derivOpInds, derivVarInds, derivParams, numDerivParamsPerDerivOp }
-:ArgumentTypes:  { Integer, Integer, Manual }
+:Pattern:        QuEST`Private`CalcGeometricTensorInternal[initStateId_Integer, workspaces_List, opcodes_List, ctrls_List, numCtrlsPerOp_List, targs_List, numTargsPerOp_List, params_List, numParamsPerOp_List, derivOpInds_List, derivVarInds_List, derivParams_List, numDerivParamsPerDerivOp_List]
+:Arguments:      { initStateId, workspaces, opcodes, ctrls, numCtrlsPerOp, targs, numTargsPerOp, params, numParamsPerOp, derivOpInds, derivVarInds, derivParams, numDerivParamsPerDerivOp }
+:ArgumentTypes:  { Integer, Manual }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`Private`CalcGeometricTensorInternal::usage = "CalcGeometricTensor[initStateId, isPureCirc, opcodes, ctrls, numCtrlsPerOp, targs, numTargsPerOp, params, numParamsPerOp, derivOpInds, derivVarInds, derivParams, numDerivParamsPerDerivOp] accepts a circuit and derivative terms and returns the corresponding geometric tensor."
+:Evaluate: QuEST`Private`CalcGeometricTensorInternal::usage = "CalcGeometricTensor[initStateId, workspaces, opcodes, ctrls, numCtrlsPerOp, targs, numTargsPerOp, params, numParamsPerOp, derivOpInds, derivVarInds, derivParams, numDerivParamsPerDerivOp] accepts a circuit and derivative terms and returns the corresponding geometric tensor."
 
 :Begin:
 :Function:       internal_calcInnerProductsMatrix

--- a/Link/templates.tm
+++ b/Link/templates.tm
@@ -431,12 +431,12 @@
 
 :Begin:
 :Function:       internal_calcQuregDerivs
-:Pattern:        QuEST`Private`CalcQuregDerivsInternal[initStateId_Integer, quregIds_List, opcodes_List, ctrls_List, numCtrlsPerOp_List, targs_List, numTargsPerOp_List, params_List, numParamsPerOp_List, derivOpInds_List, derivVarInds_List, derivParams_List, numDerivParamsPerDerivOp_List]
-:Arguments:      { initStateId, quregIds, opcodes, ctrls, numCtrlsPerOp, targs, numTargsPerOp, params, numParamsPerOp, derivOpInds, derivVarInds, derivParams, numDerivParamsPerDerivOp }
-:ArgumentTypes:  { Integer, Manual }
+:Pattern:        QuEST`Private`CalcQuregDerivsInternal[initStateId_Integer, workspaceId_Integer, quregIds_List, opcodes_List, ctrls_List, numCtrlsPerOp_List, targs_List, numTargsPerOp_List, params_List, numParamsPerOp_List, derivOpInds_List, derivVarInds_List, derivParams_List, numDerivParamsPerDerivOp_List]
+:Arguments:      { initStateId, workspaceId, quregIds, opcodes, ctrls, numCtrlsPerOp, targs, numTargsPerOp, params, numParamsPerOp, derivOpInds, derivVarInds, derivParams, numDerivParamsPerDerivOp }
+:ArgumentTypes:  { Integer, Integer, Manual }
 :ReturnType:     Manual
 :End:
-:Evaluate: QuEST`Private`CalcQuregDerivsInternal::usage = "CalcQuregDerivsInternal[initStateId, quregIds, opcodes, ctrls, numCtrlsPerOp, targs, numTargsPerOp, params, numParamsPerOp, derivOpInds, derivVarInds, derivParams, numDerivParamsPerDerivOp] accepts a circuit (complete with rotation angles) and a nominated set of gates (by indices), sets each qureg to be the result of applying the derivative of the circuit w.r.t the nominated gates, upon the initial state."
+:Evaluate: QuEST`Private`CalcQuregDerivsInternal::usage = "CalcQuregDerivsInternal[initStateId, workspaceId, quregIds, opcodes, ctrls, numCtrlsPerOp, targs, numTargsPerOp, params, numParamsPerOp, derivOpInds, derivVarInds, derivParams, numDerivParamsPerDerivOp] accepts a circuit (complete with rotation angles) and a nominated set of gates (by indices), sets each qureg to be the result of applying the derivative of the circuit w.r.t the nominated gates, upon the initial state. workspaceId = -1 will force internal temporary workspace creation."
 
 :Begin:
 :Function:       internal_calcExpecPauliStringDerivs


### PR DESCRIPTION
functions `CalcQuregDerivs[]`, `CalcExpecPauliStringDerivs[]` and `CalcGeometricTensor[]` now accept optional working registers which persisting between invocations, preclude the need to create registers on-the-fly. This has a performance benefit for large states.