### PR TITLE
v0.15

### DIFF
--- a/Link/QuESTlink.m
+++ b/Link/QuESTlink.m
@@ -649,8 +649,9 @@ Unlike UNonNorm, the given matrix is not internally treated as a unitary matrix.
         getParamDim[_?VectorQ] := 1
         getParamDim[_?MatrixQ] := 2
         getParamDim[_] := -1
-        codifyMatrixOrVector[obj_] :=
-            {getParamDim[obj]} ~Join~ Riffle[Re @ N @ Flatten @ obj, Im @ N @ Flatten @ obj]
+        codifyMatrix[obj_] := Riffle[Re @ N @ Flatten @ obj, Im @ N @ Flatten @ obj]
+        codifyMatrixOrVectorWithDim[obj_] :=
+            {getParamDim[obj]} ~Join~ codifyMatrix[obj]
             
         (* convert multiple MMA matrices into {#matrices, ... flattened matrices ...} *)
         codifyMatrices[matrs_] :=
@@ -659,7 +660,7 @@ Unlike UNonNorm, the given matrix is not internally treated as a unitary matrix.
         (* recognising and codifying gates into {opcode, ctrls, targs, params} *)
         gatePatterns = {
             Subscript[C, (ctrls:__Integer)|{ctrls:__Integer}][Subscript[g:U|Matr|UNonNorm,  (targs:__Integer)|{targs:__Integer}][obj:_List]] :> 
-                {getOpCode[g], {ctrls}, {targs}, codifyMatrixOrVector[obj]},
+                {getOpCode[g], {ctrls}, {targs}, codifyMatrixOrVectorWithDim[obj]},
         	Subscript[C, (ctrls:__Integer)|{ctrls:__Integer}][Subscript[gate_Symbol, (targs:__Integer)|{targs:__Integer}][args__]] :> 
                 {getOpCode[gate], {ctrls}, {targs}, {args}},
         	Subscript[C, (ctrls:__Integer)|{ctrls:__Integer}][Subscript[gate_Symbol, (targs:__Integer)|{targs:__Integer}]] :> 
@@ -669,7 +670,7 @@ Unlike UNonNorm, the given matrix is not internally treated as a unitary matrix.
             R[param_, ({paulis:pauliOpPatt..}|Verbatim[Times][paulis:pauliOpPatt..]|paulis:pauliOpPatt__)] :>
                 {getOpCode[R], {}, {paulis}[[All,2]], Join[{param}, getOpCode /@ {paulis}[[All,1]]]},
         	Subscript[g:U|Matr|UNonNorm, (targs:__Integer)|{targs:__Integer}][obj_List] :> 
-                {getOpCode[g], {}, {targs}, codifyMatrixOrVector[obj]},
+                {getOpCode[g], {}, {targs}, codifyMatrixOrVectorWithDim[obj]},
             Subscript[Kraus, (targs:__Integer)|{targs:__Integer}][matrs_List] :>
                 {getOpCode[Kraus], {}, {targs}, codifyMatrices[matrs]},
             Subscript[KrausNonTP, (targs:__Integer)|{targs:__Integer}][matrs_List] :>

--- a/Link/circuits.cpp
+++ b/Link/circuits.cpp
@@ -268,6 +268,13 @@ std::string Gate::getSyntax() {
             case OPCODE_U :
             case OPCODE_UNonNorm :
             case OPCODE_Matr :
+                // The below code exposes a (still unpatched, grr) bug in the Mathematica frontend
+                // whereby formatted expressions sometimes cause the entire Message[] contents to become
+                // hidden (depending on frontned window width), replaced with something like: <<<527>>>.
+                // Until this is resolved, we will not attempt to render a formatted matrix.
+                form += "[\"...\"]";
+                break;
+                /*
                 if (local_isEncodedMatrix(params[0])) {
                     int dim = round(sqrt((numParams-1)/2));
                     qmatrix matr = local_getQmatrixFromFlatList(&params[1], dim);
@@ -279,10 +286,18 @@ std::string Gate::getSyntax() {
                 } else
                     form += "[uninterpretable]";
                 break;
+                */
                 
             // complex matrices
             case OPCODE_Kraus :
             case OPCODE_KrausNonTP :
+                // Like above, the below code exposes a (still unpatched, grr) bug in the Mathematica frontend
+                // whereby formatted expressions sometimes cause the entire Message[] contents to become
+                // hidden (depending on frontned window width), replaced with something like: <<<527>>>.
+                // Until this is resolved, we will not attempt to render a formatted matrix(ces).
+                form += "[\"...\"]";
+                break;
+                /*
                 if (numParams < 0)
                     form += "[]";
                 else if (!local_isInt(params[0]))
@@ -305,6 +320,7 @@ std::string Gate::getSyntax() {
                     }
                 }
                 break;
+                */
                 
             // complex scalar
             case OPCODE_Fac :


### PR DESCRIPTION
This minor release patches two bugs introduced in `v0.14`.

## Bug fixes

- restored passing of `Kraus` and `KrausNonTP` operators to `ApplyCircuit` (and to related functions like `ApplyCircuitDerivs`). Version `v0.14` changed how Mathematica matrices are encoded into C++ structures,  so that gates `U`, `UNonNorm` and `Matr` can accept matrices specified diagonally. This inadvertently disabled passing `Kraus` operator matrices.
- temporarily disabled pretty frontend rendering of matrices (via `MatrixForm`) in the error messages of operators `U`, `UNonNorm`, `Matr`, `Kraus` and `KrausNonTP`. While implemented correctly, these renderings sometimes invoked an outstanding Mathematica notebook bug, causing the entire error message to be hidden (and replaced with obscure text like `<<<527>>>`). 
  
  As a result, a previous error message like:
  > <img width="355" alt="image" src="https://github.com/QTechTheory/QuESTlink/assets/29574749/769578f1-64d4-4db2-807d-03352a23c315">
  
  will now be rendered as:
  > <img width="327" alt="image" src="https://github.com/QTechTheory/QuESTlink/assets/29574749/e2945cdb-dfec-434a-9eef-f142fc9e55bd">
  
  so as to avoid invoking the occassional Mathematica frontend bug and rendering as
  > <img width="327" alt="image" src="https://github.com/QTechTheory/QuESTlink/assets/29574749/20d5c694-a992-4cba-83b5-47ef0d09c97d">

