### PR TITLE
added GetQuregState

### DIFF
--- a/Link/QuESTlink.m
+++ b/Link/QuESTlink.m
@@ -580,7 +580,10 @@ Unlike UNonNorm, the given matrix is not internally treated as a unitary matrix.
             
 
         GetQuregMatrix[args___] := (
-            Message[GetQuregState::error, "The deprecated function GetQuregMatrix[] has been automatically replaced with GetQuregState[]. In future, please use GetQuregState[], or temporarily hide this message using Quiet[]."];
+            (* temporarily hide the deprecation notice, so existing code doesn't yet need to be updated *)
+            (*
+                Message[GetQuregState::error, "The deprecated function GetQuregMatrix[] has been automatically replaced with GetQuregState[]. In future, please use GetQuregState[], or temporarily hide this message using Quiet[]."];
+            *)
             GetQuregState[args])
            
             

--- a/Link/link.cpp
+++ b/Link/link.cpp
@@ -328,7 +328,7 @@ void internal_getQuregMatrix(int id) {
         WSPutQrealList(stdlink, qureg.stateVec.imag, qureg.numAmpsTotal);    
         
     } catch (QuESTException& err) {
-        local_sendErrorAndFail("GetQuregMatrix", err.message);
+        local_sendErrorAndFail("GetQuregState", err.message);
     }
 }
 


### PR DESCRIPTION
which deprecates `GetQuregMatrix`, and has an additional `"ZBasisKets"` method