### PR TITLE
fixed external CI dependency versions

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -100,19 +100,19 @@ jobs:
         run: |
           rm -rf Binaries
           mkdir Binaries
-      - uses: actions/download-artifact@main
+      - uses: actions/download-artifact@v3
         with:
           name: linux_quest_link
           path: Binaries
-      - uses: actions/download-artifact@main
+      - uses: actions/download-artifact@v3
         with:
           name: macos_x86_quest_link
           path: Binaries
-      - uses: actions/download-artifact@main
+      - uses: actions/download-artifact@v3
         with:
           name: macos_arm_quest_link
           path: Binaries
-      - uses: actions/download-artifact@main
+      - uses: actions/download-artifact@v3
         with:
           name: windows_quest_link
           path: Binaries
@@ -123,7 +123,7 @@ jobs:
           git add Binaries
           git commit -m "Update precompiled binaries"
       - name: Push recompiled binaries
-        uses: ad-m/github-push-action@main
+        uses: ad-m/github-push-action@v0.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: main


### PR DESCRIPTION
We previously dangerously pulled the latest versions, but a change in a github action broke our CI. Now, we refer explicitly to a previous version